### PR TITLE
Switch to new Kavita image

### DIFF
--- a/apps/kavita/config.json
+++ b/apps/kavita/config.json
@@ -5,8 +5,8 @@
   "available": true,
   "exposable": true,
   "id": "kavita",
-  "tipi_version": 6,
-  "version": "0.7.8",
+  "tipi_version": 7,
+  "version": "0.7.9",
   "categories": [
     "media"
   ],

--- a/apps/kavita/docker-compose.yml
+++ b/apps/kavita/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   kavita:
     container_name: kavita
-    image: kizaing/kavita:0.7.8
+    image: jvmilazz0/kavita:0.7.9
     ports:
       - ${APP_PORT}:5000
     volumes:


### PR DESCRIPTION
The [new release of Kavita](https://github.com/Kareadita/Kavita/releases/tag/v0.7.9) moved the image to a [new repository in Docker Hub](https://hub.docker.com/r/jvmilazz0/kavita) so I'm reflecting that in the Tipi app.