### PR TITLE
Making settings dynamic (Gitea)

### DIFF
--- a/apps/gitea/data/gitea/gitea/conf/app.ini.template
+++ b/apps/gitea/data/gitea/gitea/conf/app.ini.template
@@ -16,13 +16,13 @@ PATH=/data/git/lfs
 
 [server]
 APP_DATA_PATH    = /data/gitea
-DOMAIN           = localhost
-SSH_DOMAIN       = localhost
+DOMAIN           = {{APP_HOST}}
+SSH_DOMAIN       = {{APP_HOST}}
 HTTP_PORT        = 3000
-ROOT_URL         = http://localhost:8108/
+ROOT_URL         = https://{{APP_DOMAIN}}/
 DISABLE_SSH      = false
-SSH_PORT         = 22
-SSH_LISTEN_PORT  = 22
+SSH_PORT         = 222
+SSH_LISTEN_PORT  = 222
 LFS_START_SERVER = true
 LFS_JWT_SECRET   = wo2G20l0nGsspUp8xsLNSNF7H8U-GQUVth5gj_q5cDk
 OFFLINE_MODE     = false


### PR DESCRIPTION
See #1423 for details for PR reason.

From testing I was able to do on my local machine theses are the manual testing I was able to do successfully.
- Account creation works for non exposed app 
- URL's for clone are correct for non exposed app. (HTTP(s) + SSH)
- Able to push through HTTP(S) URL

Was not able to test with an exposed app but the `app.ini` did show correct values compared to manual one I used in my personal server's config.

Was ***not able to push though SSH*** on a non exposed app. I'm not sure why but think it has to do with my local machine. This should be verified by someone else though.