### PR TITLE
Update Nextcloud to v26

### DIFF
--- a/apps/nextcloud/config.json
+++ b/apps/nextcloud/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8083,
   "id": "nextcloud",
-  "tipi_version": 18,
-  "version": "25.0.13-apache",
+  "tipi_version": 19,
+  "version": "26.0.8-apache",
   "categories": [
     "data"
   ],

--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   nextcloud:
     container_name: nextcloud
-    image: nextcloud:25.0.13-apache
+    image: nextcloud:26.0.8-apache
     restart: unless-stopped
     ports:
       - ${APP_PORT}:80


### PR DESCRIPTION
Nextcloud 25.0.13 is the last update in the v25 branch, after that this major version is EOL. However Nextcloud cannot gracefully upgrade to the latest major version v27, because there's some internal migrations in Nextcloud that won't work between two major versions. So I upgraded the app to the latest v26 image instead, which is `26.0.8`.