### PR TITLE
fix(changedetection): remove chrome container

### DIFF
--- a/apps/changedetection/docker-compose.yml
+++ b/apps/changedetection/docker-compose.yml
@@ -40,10 +40,10 @@ services:
         traefik.http.routers.changedetection-web-local.tls: true
 
 
-    chnagedetection-chrome:
-      hostname: chnagedetection-chrome
-      image: browserless/chrome:latest
-      restart: unless-stopped
-      container_name: chnagedetection-chrome
-      networks:
-        - tipi_main_network
+    # chnagedetection-chrome:
+    #   hostname: chnagedetection-chrome
+    #   image: browserless/chrome:latest
+    #   restart: unless-stopped
+    #   container_name: chnagedetection-chrome
+    #   networks:
+    #     - tipi_main_network


### PR DESCRIPTION
Chrome container image is 1.17gb in size and quite heavy. Since its not required by changedetection it would be just a custom user config.