### PR TITLE
[FIX] Change path to match default config

### DIFF
--- a/apps/transmission/config.json
+++ b/apps/transmission/config.json
@@ -10,7 +10,7 @@
     ]
   },
   "id": "transmission",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "4.0.5",
   "categories": [
     "utilities"

--- a/apps/transmission/docker-compose.yml
+++ b/apps/transmission/docker-compose.yml
@@ -11,13 +11,10 @@ services:
       - TZ=${TZ}
       - USER=${TRANSMISSION_USERNAME}
       - PASS=${TRANSMISSION_PASSWORD}
-      # - TRANSMISSION_WEB_HOME=/transmission-web-control/
-      # - WHITELIST=iplist #optional
-      # - PEERPORT=peerport #optional
-      # - HOST_WHITELIST=dnsnane list #optional
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      - ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
+      - ${ROOT_FOLDER_HOST}/media/torrents:/downloads
+      - ${ROOT_FOLDER_HOST}/media/watch:/watch
     ports:
       - ${APP_PORT}:9091
       - 51413:51413

--- a/apps/transmission/metadata/description.md
+++ b/apps/transmission/metadata/description.md
@@ -10,7 +10,8 @@ Visit [https://transmissionbt.com/](https://transmissionbt.com/) for more inform
 
 ## Folder Info
 
-| Root Folder                   | Container Folder |
-|-------------------------------|------------------|
+| Root Folder                                | Container Folder |
+|--------------------------------------------|------------------|
 | /runtipi/app-data/transmission/data/config | /config          |
-| /runtipi/media/torrents                | /media/torrents       |
+| /runtipi/media/torrents                    | /downloads       |
+| /runtipi/media/watch                       | /watch           |


### PR DESCRIPTION
Change path to match default transmission configuration as specified in docker hub documentation : 
https://hub.docker.com/r/linuxserver/transmission

![image](https://github.com/runtipi/runtipi-appstore/assets/1827520/d0795fcd-f1b4-4a4e-bcc3-058f9ef5348b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Transmission application path mapping in the documentation to reflect the change from `media/torrents` to `downloads`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->