### PR TITLE
refactor(tests): do not check strictly for the tipi network

### DIFF
--- a/apps/__tests__/apps.test.ts
+++ b/apps/__tests__/apps.test.ts
@@ -259,9 +259,9 @@ describe("App configs", () => {
           expect(dockerCompose.services[app.id]).toBeDefined();
 
           expect(dockerCompose.services[app.id].networks).toBeDefined();
-          expect(dockerCompose.services[app.id].networks).toStrictEqual([
-            "tipi_main_network",
-          ]);
+          expect(dockerCompose.services[app.id].networks).toContain(
+            "tipi_main_network"
+          );
         }
       });
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the network presence assertion logic in `dockerCompose` services tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->