### PR TITLE
Update: qbittorrent description

### DIFF
--- a/apps/qbittorrent/metadata/description.md
+++ b/apps/qbittorrent/metadata/description.md
@@ -4,8 +4,12 @@ The [Qbittorrent](https://www.qbittorrent.org/) project aims to provide an open-
 
 ## Credentials
 
-Username: admin
-Password: adminadmin
+Please note that starting from version 4.6.1, qBittorrent no longer provides a default password. Instead, a randomly generated password is used and can be found in the container logs. Please check the logs for the password. Alternatively, you can manually modify the config file to set it to the hash of `adminadmin`. Example:
+
+```
+ [Preferences]
+WebUI\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)" 
+```
 
 ## Folder Info 
 


### PR DESCRIPTION
qBittorrent dropped the default password since 4.6.1.
A password is randomly generated on first run (see [release notes](https://www.qbittorrent.org/news) for 4.6.1)

Leaving the default credentials will confuse users (see #2159). So I am just updating the description here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Updates**
  - Default qBittorrent credentials updated for enhanced security; a randomly generated password is now created and can be retrieved from the container logs. Users can also set a custom password manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->