### PR TITLE
Bug fixes for Calcom

### DIFF
--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -110,7 +110,7 @@
   "supported_architectures": [
     "amd64"
   ],
-  "tipi_version": 5,
-  "version": "3.8.3",
+  "tipi_version": 6,
+  "version": "3.7.16",
   "website": "https://cal.com/"
 }

--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -19,8 +19,8 @@
     {
       "env_variable": "CALENDSO_ENCRYPTION_KEY",
       "label": "Random string",
-      "max": 50,
-      "min": 50,
+      "max": 32,
+      "min": 32,
       "type": "random"
     },
     {

--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -110,7 +110,7 @@
   "supported_architectures": [
     "amd64"
   ],
-  "tipi_version": 4,
-  "version": "3.7.16",
+  "tipi_version": 5,
+  "version": "3.8.3",
   "website": "https://cal.com/"
 }

--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -70,6 +70,14 @@
       "type": "email"
     },
     {
+        "type": "email",
+        "label": "Email server username (SMTP)",
+        "required": true,
+        "min": 1,
+        "max": 1024,
+        "env_variable": "EMAIL_SERVER_USER"
+    },
+    {
       "env_variable": "EMAIL_SERVER_HOST",
       "label": "Email server host (SMTP)",
       "max": 1024,

--- a/apps/calcom/docker-compose.yml
+++ b/apps/calcom/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   calcom:
     container_name: calcom
-    image: calcom/cal.com:v3.8.3
+    image: calcom/cal.com:v3.7.16
     restart: unless-stopped
     ports:
       - ${APP_PORT}:3000

--- a/apps/calcom/docker-compose.yml
+++ b/apps/calcom/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - DATABASE_HOST=db-calcom
       - DATABASE_URL=postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@db-calcom/calcom
+      - DATABASE_DIRECT_URL=postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@db-calcom/calcom
       - POSTGRES_USER=${POSTGRES_USERNAME}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=calcom

--- a/apps/calcom/docker-compose.yml
+++ b/apps/calcom/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   calcom:
     container_name: calcom
-    image: calcom/cal.com:v3.7.16
+    image: calcom/cal.com:v3.8.3
     restart: unless-stopped
     ports:
       - ${APP_PORT}:3000

--- a/apps/calcom/docker-compose.yml
+++ b/apps/calcom/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - EMAIL_SERVER_HOST=${EMAIL_SERVER_HOST}
       - EMAIL_SERVER_PORT=${EMAIL_SERVER_PORT}
       - EMAIL_SERVER_PASSWORD=${EMAIL_SERVER_PASSWORD}
+      - EMAIL_SERVER_USER=${EMAIL_SERVER_USER}
       - NODE_ENV=production
     labels:
       # Main


### PR DESCRIPTION
- Adds email server username env var and form field
- Adds new env var that is required after the auto-update to 3.7.16 (`DATABASE_DIRECT_URL`)
- Changes encryption key form field length to 32