### PR TITLE
fix: atuin database not initialiazing on fresh install

### DIFF
--- a/apps/atuin/docker-compose.yml
+++ b/apps/atuin/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     image: postgres:14
     restart: unless-stopped
     volumes: # Don't remove permanent storage for index database files!
-      - "${APP_DATA_DIR}/data:/var/lib/postgresql/data/"
+      - "${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data/"
     environment:
       POSTGRES_USER: atuin
       POSTGRES_PASSWORD: "${ATUIN_DB_PASSWORD}"


### PR DESCRIPTION
- commit 29112c8 changed atuin volume to `${APP_DATA_DIR}/data/config` and this causes the database to fail because the data dir is no longer empty
- this commit adds a dedicated directory 'postgres' for database volume

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>