### PR TITLE
[APP] Atuin: switch to explicit tag

### DIFF
--- a/apps/atuin/config.json
+++ b/apps/atuin/config.json
@@ -5,9 +5,12 @@
   "exposable": true,
   "port": 8888,
   "id": "atuin",
-  "tipi_version": 2,
-  "version": "latest",
-  "categories": ["utilities", "development"],
+  "tipi_version": 3,
+  "version": "18.1.0",
+  "categories": [
+    "utilities",
+    "development"
+  ],
   "description": "Making your shell magical",
   "short_desc": "Magical Shell History",
   "author": "https://github.com/atuinsh",
@@ -30,5 +33,8 @@
       "env_variable": "ATUIN_ALLOW_REGISTRATION"
     }
   ],
-  "supported_architectures": ["amd64", "arm64"]
+  "supported_architectures": [
+    "amd64",
+    "arm64"
+  ]
 }

--- a/apps/atuin/docker-compose.yml
+++ b/apps/atuin/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   atuin:
     container_name: atuin
     restart: always
-    image: ghcr.io/atuinsh/atuin:latest
+    image: ghcr.io/atuinsh/atuin:18.1.0
     command: server start
     volumes:
       - "${APP_DATA_DIR}/data/config:/config"


### PR DESCRIPTION
If i understand things correctly this will enlist Atuin in Renovate docker tag updates and thereby into Tipi UI-managed updates, which I think is also Tipi best practice and Atuin's maintainers' suggestion - i just didn't know enough when i opened the original PR.