### PR TITLE
Add sudo password

### DIFF
--- a/apps/code-server/config.json
+++ b/apps/code-server/config.json
@@ -22,7 +22,7 @@
       "min": 3,
       "required": true,
       "env_variable": "CODESERVER_PASSWORD"
-    }
+    },
     {
       "type": "password",
       "label": "Sudo Password",

--- a/apps/code-server/config.json
+++ b/apps/code-server/config.json
@@ -5,7 +5,7 @@
   "exposable": true,
   "port": 8138,
   "id": "code-server",
-  "tipi_version": 25,
+  "tipi_version": 26,
   "version": "4.22.1",
   "categories": [
     "development"

--- a/apps/code-server/config.json
+++ b/apps/code-server/config.json
@@ -23,6 +23,14 @@
       "required": true,
       "env_variable": "CODESERVER_PASSWORD"
     }
+    {
+      "type": "password",
+      "label": "Sudo Password",
+      "max": 50,
+      "min": 3,
+      "required": true,
+      "env_variable": "SUDO_PASSWORD"
+    }
   ],
   "supported_architectures": [
     "arm64",

--- a/apps/code-server/docker-compose.yml
+++ b/apps/code-server/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - PGID=1000
       - TZ=${TZ}
       - PASSWORD=${CODESERVER_PASSWORD}
+      - SUDO_PASSWORD=${SUDO_PASSWORD}
       - DEFAULT_WORKSPACE=/config/workspace #optional
     volumes:
       - ${APP_DATA_DIR}/data/config:/config #config dir


### PR DESCRIPTION
This password permit install packages on debian container for improve functionalities, like git, ansible, and others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Added a new configuration field for "Sudo Password" with constraints on length and type.
	- Added the `SUDO_PASSWORD` environment variable to the `code-server` service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->