### PR TITLE
[FlareSolverr] Update default port number

### DIFF
--- a/apps/flaresolverr/config.json
+++ b/apps/flaresolverr/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../schema.json",
   "name": "Flaresolverr",
-  "port": 8666,
+  "port": 8191,
   "available": true,
   "exposable": false,
   "no_gui": true,


### PR DESCRIPTION
The correct port is 8191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Flaresolverr service port configuration for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->