### PR TITLE
[FIX] Planning Poker - Force Health Check to use IPV4 instead of IPV6…

### DIFF
--- a/apps/planning-poker/docker-compose.yml
+++ b/apps/planning-poker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - tipi_main_network
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8000
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8000
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
… due to gunicorn bind declared as IPV4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the health check URL in the Planning Poker application for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->