### PR TITLE
Add label `update-image` to renovate bot PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "gitIgnoredAuthors": ["githubaction@githubaction.com"],
   "dependencyDashboard": true,
   "enabledManagers": ["docker-compose", "dockerfile"],
+  "labels": ["update-image"],
   "hostRules": [
     {
       "matchHost": "index.docker.io",


### PR DESCRIPTION
Add the label `update-image` to the pr created by renovate bot, like dependabot does with `dependencies`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to automatically label image updates in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->