### PR TITLE
Fix invidious healthcheck

### DIFF
--- a/apps/invidious/config.json
+++ b/apps/invidious/config.json
@@ -6,7 +6,7 @@
   "port": 8095,
   "id": "invidious",
   "version": "latest",
-  "tipi_version": 7,
+  "tipi_version": 8,
   "categories": ["media", "social"],
   "description": "Invidious is an open source alternative front-end to YouTube.",
   "short_desc": "An alternative front-end to YouTube",

--- a/apps/invidious/docker-compose.arm64.yml
+++ b/apps/invidious/docker-compose.arm64.yml
@@ -19,13 +19,10 @@ services:
         check_tables: true
         hmac_key: ${INVIDIOUS_HMAC_KEY}
     healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s
       timeout: 5s
       retries: 2
-    depends_on:
-      invidious-db:
-        condition: service_healthy
     networks:
       - tipi_main_network
     labels:

--- a/apps/invidious/docker-compose.yml
+++ b/apps/invidious/docker-compose.yml
@@ -20,13 +20,10 @@ services:
         check_tables: true
         hmac_key: ${INVIDIOUS_HMAC_KEY}
     healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/comments/jNQXAC9IVRw || exit 1
+      test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s
       timeout: 5s
       retries: 2
-    depends_on:
-      invidious-db:
-        condition: service_healthy
     networks:
       - tipi_main_network
     labels:


### PR DESCRIPTION
This mirrors the commits https://github.com/iv-org/invidious/commit/1e6ec605e88d1874e1b8b99294312a3c51f07beb and https://github.com/iv-org/invidious/commit/170eef58fd907057782244c95f9b8d72bb85d114 into the Tipi app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the health check URL to monitor trending content instead of comments, ensuring better service reliability.

- **Chores**
  - Updated the application version to enhance compatibility and performance.
  - Removed an unnecessary dependency condition to streamline service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->