### PR TITLE
Invidious config for captions

### DIFF
--- a/apps/invidious/config.json
+++ b/apps/invidious/config.json
@@ -6,7 +6,7 @@
   "port": 8095,
   "id": "invidious",
   "version": "latest",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "categories": ["media", "social"],
   "description": "Invidious is an open source alternative front-end to YouTube.",
   "short_desc": "An alternative front-end to YouTube",

--- a/apps/invidious/docker-compose.arm64.yml
+++ b/apps/invidious/docker-compose.arm64.yml
@@ -18,6 +18,7 @@ services:
           port: 5432
         check_tables: true
         hmac_key: ${INVIDIOUS_HMAC_KEY}
+        use_innertube_for_captions: true
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s

--- a/apps/invidious/docker-compose.yml
+++ b/apps/invidious/docker-compose.yml
@@ -19,6 +19,7 @@ services:
           port: 5432
         check_tables: true
         hmac_key: ${INVIDIOUS_HMAC_KEY}
+        use_innertube_for_captions: true
     healthcheck:
       test: wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1
       interval: 30s


### PR DESCRIPTION
Use innertube for captions, which is more reliable. E.g. it helps with large instances, as well with auto-translated captions
It should be the default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled a new feature for improved handling of captions in the Invidious service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->