### PR TITLE
Fix: update version in config.json (app/bitcoind)

### DIFF
--- a/apps/bitcoind/config.json
+++ b/apps/bitcoind/config.json
@@ -8,7 +8,7 @@
   "id": "bitcoind",
   "description": "Bitcoin core node",
   "tipi_version": 2,
-  "version": "26.0",
+  "version": "27.0",
   "categories": [
     "finance"
   ],


### PR DESCRIPTION
I see that in some PR there is a commit that update the version in the config with the same version in the docker-comopse (for [example](https://github.com/runtipi/runtipi-appstore/pull/3404/commits/01e2f669b698da96eea2e1050b7cb2f863f3f0ca)), but idk why that didnt happend in #3260.