### PR TITLE
fix(invoice-ninja): wrong version and missing arm64 architecture

### DIFF
--- a/apps/invoice-ninja/config.json
+++ b/apps/invoice-ninja/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "id": "invoice-ninja",
   "tipi_version": 1,
-  "version": "1.25",
+  "version": "5.8.54",
   "categories": ["finance"],
   "description": "Invoice Ninja is an invoicing application which makes sending invoices and receiving payments simple and easy. Our latest version is a clean slate rewrite of our popular invoicing application which builds on the existing feature set and adds a wide range of features and enhancements the community has asked for.",
   "short_desc": "Invoices, Expenses and Tasks built with Laravel, Flutter and React.",
@@ -38,5 +38,8 @@
       "env_variable": "INVOICE_NINJA_APP_KEY"
     }
   ],
-  "supported_architectures": ["amd64"]
+  "supported_architectures": [
+    "arm64",
+    "amd64"
+  ]
 }


### PR DESCRIPTION
Wrong version of invoice ninja and missing arm64 architecture preventing the app to be installed on raspberry pi for example. 

In the [official docker files repo](https://github.com/invoiceninja/dockerfiles) there is `Running on ARM64 (Raspberry Pi 4)` section which requires using `mariadb` instead of `mysql` which was already updated here.

I have tested the installation and it works!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "arm64" architecture, expanding compatibility to more devices.

- **Updates**
  - Updated the application version from "1.25" to "5.8.54".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->