### PR TITLE
fix(invoice-ninja): broken compose project

### DIFF
--- a/apps/invoice-ninja/data/nginx/invoice-ninja.conf
+++ b/apps/invoice-ninja/data/nginx/invoice-ninja.conf
@@ -25,7 +25,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass invoice-ninja-server:9000;
+        fastcgi_pass invoice-ninja:9000;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/apps/invoice-ninja/docker-compose.yml
+++ b/apps/invoice-ninja/docker-compose.yml
@@ -1,6 +1,44 @@
-version: "3.9"
-
 services:
+  invoice-ninja-web:
+    image: nginx:1.25
+    container_name: invoice-ninja-web
+    restart: unless-stopped
+    volumes:
+      - ${APP_DATA_DIR}/data/nginx/invoice-ninja.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${APP_DATA_DIR}/data/public:/var/www/app/public:ro
+    depends_on:
+      invoice-ninja:
+        condition: service_started
+    ports:
+      - ${APP_PORT}:80
+    networks:
+      - tipi_main_network
+    labels:
+      # Main
+      traefik.enable: true
+      traefik.http.middlewares.invoice-ninja-web-redirect.redirectscheme.scheme: https
+      traefik.http.services.invoice-ninja.loadbalancer.server.port: 80
+      # Web
+      traefik.http.routers.invoice-ninja-web-insecure.rule: Host(`${APP_DOMAIN}`)
+      traefik.http.routers.invoice-ninja-web-insecure.entrypoints: web
+      traefik.http.routers.invoice-ninja-web-insecure.service: invoice-ninja-web
+      traefik.http.routers.invoice-ninja-web-insecure.middlewares: invoice-ninja-web-redirect
+      # Websecure
+      traefik.http.routers.invoice-ninja-web.rule: Host(`${APP_DOMAIN}`)
+      traefik.http.routers.invoice-ninja-web.entrypoints: websecure
+      traefik.http.routers.invoice-ninja-web.service: invoice-ninja-web
+      traefik.http.routers.invoice-ninja-web.tls.certresolver: myresolver
+      # Local domain
+      traefik.http.routers.invoice-ninja-web-local-insecure.rule: Host(`invoice-ninja.${LOCAL_DOMAIN}`)
+      traefik.http.routers.invoice-ninja-web-local-insecure.entrypoints: web
+      traefik.http.routers.invoice-ninja-web-local-insecure.service: invoice-ninja-web
+      traefik.http.routers.invoice-ninja-web-local-insecure.middlewares: invoice-ninja-web-redirect
+      # Local domain secure
+      traefik.http.routers.invoice-ninja-web-local.rule: Host(`invoice-ninja.${LOCAL_DOMAIN}`)
+      traefik.http.routers.invoice-ninja-web-local.entrypoints: websecure
+      traefik.http.routers.invoice-ninja-web-local.service: invoice-ninja-web
+      traefik.http.routers.invoice-ninja-web-local.tls: true
+
   invoice-ninja:
     image: invoiceninja/invoiceninja:5.8.54
     container_name: invoice-ninja
@@ -9,7 +47,7 @@ services:
     environment:
       - IN_USER_EMAIL=${INVOICE_NINJA_USER_MAIL}
       - IN_PASSWORD=${INVOICE_NINJA_USER_PASSWORD}
-      - APP_URL=http://invoice-ninja
+      - APP_URL=http://invoice-ninja-web
       - APP_KEY=${INVOICE_NINJA_APP_KEY}
       - APP_CIPHER=AES-256-CBC
       - DB_HOST=invoice-ninja-db
@@ -31,46 +69,6 @@ services:
     networks:
       - tipi_main_network
 
-  invoice-ninja-web:
-    image: nginx:1.25
-    container_name: invoice-ninja-web
-    restart: unless-stopped
-    volumes:
-      - ${APP_DATA_DIR}/data/nginx/invoice-ninja.conf:/etc/nginx/conf.d/default.conf:ro
-      - ${APP_DATA_DIR}/data/public:/var/www/app/public:ro
-    depends_on:
-      invoice-ninja-server:
-        condition: service_started
-    ports:
-      - ${APP_PORT}:80
-    networks:
-      - tipi_main_network
-    labels:
-      # Main
-      traefik.enable: true
-      traefik.http.middlewares.invoice-ninja-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.invoice-ninja.loadbalancer.server.port: 80
-      # Web
-      traefik.http.routers.invoice-ninja-insecure.rule: Host(`${APP_DOMAIN}`)
-      traefik.http.routers.invoice-ninja-insecure.entrypoints: web
-      traefik.http.routers.invoice-ninja-insecure.service: invoice-ninja
-      traefik.http.routers.invoice-ninja-insecure.middlewares: invoice-ninja-web-redirect
-      # Websecure
-      traefik.http.routers.invoice-ninja.rule: Host(`${APP_DOMAIN}`)
-      traefik.http.routers.invoice-ninja.entrypoints: websecure
-      traefik.http.routers.invoice-ninja.service: invoice-ninja
-      traefik.http.routers.invoice-ninja.tls.certresolver: myresolver
-      # Local domain
-      traefik.http.routers.invoice-ninja-local-insecure.rule: Host(`invoice-ninja.${LOCAL_DOMAIN}`)
-      traefik.http.routers.invoice-ninja-local-insecure.entrypoints: web
-      traefik.http.routers.invoice-ninja-local-insecure.service: invoice-ninja
-      traefik.http.routers.invoice-ninja-local-insecure.middlewares: invoice-ninja-web-redirect
-      # Local domain secure
-      traefik.http.routers.invoice-ninja-local.rule: Host(`invoice-ninja.${LOCAL_DOMAIN}`)
-      traefik.http.routers.invoice-ninja-local.entrypoints: websecure
-      traefik.http.routers.invoice-ninja-local.service: invoice-ninja
-      traefik.http.routers.invoice-ninja-local.tls: true
-
   invoice-ninja-db:
     image: mariadb:10.4
     container_name: invoice-ninja-db
@@ -88,14 +86,7 @@ services:
       invoice-ninja-init:
         condition: service_completed_successfully
     healthcheck:
-      test:
-        [
-          "CMD",
-          "healthcheck.sh",
-          "--su-mysql",
-          "--connect",
-          "--innodb_initialized",
-        ]
+      test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixing  `service "invoice-ninja-web" depends on undefined service "invoice-ninja-server": invalid compose project` error introduced in c0e0435d588946ee11129809d8a638d189c46687.
```
worker: 2024-05-16T18:24:18.715Z - info > 	Installing app invoice-ninja as User ID: 0, Group ID: 0
worker: 2024-05-16T18:24:18.719Z - info > 	Deleting folder /data/apps/invoice-ninja if exists
worker: 2024-05-16T18:24:18.728Z - info > 	Creating folder /data/apps/invoice-ninja
worker: 2024-05-16T18:24:18.729Z - info > 	Copying folder /data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/invoice-ninja to /data/apps/invoice-ninja
worker: 2024-05-16T18:24:18.762Z - info > 	Creating folder /app-data/invoice-ninja
worker: 2024-05-16T18:24:18.762Z - info > 	Creating app.env file for app invoice-ninja
worker: 2024-05-16T18:24:18.767Z - info > 	Copying data dir for app invoice-ninja
worker: 2024-05-16T18:24:18.771Z - info > 	Running docker-compose up for app invoice-ninja
worker: 2024-05-16T18:24:18.773Z - info > 	Running docker compose with args --env-file /app-data/invoice-ninja/app.env --project-name invoice-ninja -f /data/apps/invoice-ninja/docker-compose.yml -f /data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/docker-compose.common.yml up --detach --force-recreate --remove-orphans --pull always
worker: 2024-05-16T18:24:18.836Z - error > 	An error occurred: Command failed: docker-compose --env-file /app-data/invoice-ninja/app.env --project-name invoice-ninja -f /data/apps/invoice-ninja/docker-compose.yml -f /data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/docker-compose.common.yml up --detach --force-recreate --remove-orphans --pull always
time="2024-05-16T18:24:18Z" level=warning msg="/data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/docker-compose.common.yml: `version` is obsolete"
service "invoice-ninja-web" depends on undefined service "invoice-ninja-server": invalid compose project
2024-05-16T18:24:18.842Z > Failed to install app invoice-ninja: Command failed: docker-compose --env-file /app-data/invoice-ninja/app.env --project-name invoice-ninja -f /data/apps/invoice-ninja/docker-compose.yml -f /data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/docker-compose.common.yml up --detach --force-recreate --remove-orphans --pull always
time="2024-05-16T18:24:18Z" level=warning msg="/data/repos/a15266f4aa37dd40ac596a3f896093fe9c3901e5de0ababceea4c0f5deefcdde/apps/docker-compose.common.yml: `version` is obsolete"
service "invoice-ninja-web" depends on undefined service "invoice-ninja-server": invalid compose project
```

FYI @meienberger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Corrected service dependency name in `docker-compose.yml` to ensure proper service startup and dependencies management.
- **Refactor**
  - Updated service configurations in `docker-compose.yml` to improve service communication and routing efficiency.
  - Modified `fastcgi_pass` directive in `invoice-ninja.conf` to align with updated service naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->