### PR TITLE
fix(n8n): fix initialization error

### DIFF
--- a/apps/n8n-1/config.json
+++ b/apps/n8n-1/config.json
@@ -5,9 +5,11 @@
   "exposable": true,
   "port": 8215,
   "id": "n8n-1",
-  "tipi_version": 2,
-  "version": "1.30.1",
-  "categories": ["automation"],
+  "tipi_version": 3,
+  "version": "1.42.1",
+  "categories": [
+    "automation"
+  ],
   "description": "n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, be available to self-host, and allow you to add your own custom functions, logic and apps. n8n's node-based approach makes it highly versatile, enabling you to connect anything to everything.",
   "short_desc": "Workflow Automation Tool. Alternative to Zapier",
   "author": "n8n.io",
@@ -27,5 +29,8 @@
       "env_variable": "N8N_NR_DB_PASSWORD"
     }
   ],
-  "supported_architectures": ["arm64", "amd64"]
+  "supported_architectures": [
+    "arm64", 
+    "amd64"
+  ]
 }

--- a/apps/n8n-1/docker-compose.yml
+++ b/apps/n8n-1/docker-compose.yml
@@ -1,9 +1,8 @@
-version: "3.7"
 
 services:
   n8n-1:
     container_name: n8n-1
-    image: n8nio/n8n:1.30.1
+    image: n8nio/n8n:1.42.1
     restart: unless-stopped
     ports:
       - ${APP_PORT}:5678
@@ -11,6 +10,7 @@ services:
       - ${APP_DATA_DIR}/data/n8n:/home/node/.n8n
     environment:
       - N8N_EDITOR_BASE_URL=${APP_PROTOCOL:-http}://${APP_DOMAIN}
+      - N8N_SECURE_COOKIE=false
       - WEBHOOK_URL=${APP_PROTOCOL:-http}://${APP_DOMAIN}
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_HOST=n8n-db
@@ -23,6 +23,8 @@ services:
     links:
       - n8n-db
     depends_on:
+      n8n-init:
+        condition: service_completed_successfully
       n8n-db:
         condition: service_healthy
     labels:
@@ -75,3 +77,9 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+  
+  n8n-init:
+    image: bash:5.2.26
+    command: ['sh', '-c', 'chown -R 1000:1000 /home/node/.n8n']
+    volumes:
+      - ${APP_DATA_DIR}/data/n8n:/home/node/.n8n


### PR DESCRIPTION
Updating the n8n to latest version 1.42.1 Closes #2577

Also addressed where initialization failed because of:

```
(node:7) [EACCES] Error Plugin: n8n: EACCES: permission denied, open '/home/node/.n8n/config'
module: @oclif/core@3.18.1
task: cacheCommand
plugin: n8n
root: /usr/local/lib/node_modules/n8n
See more details with DEBUG=*
```

References: 

- https://github.com/n8n-io/n8n/issues/8272
- https://github.com/n8n-io/n8n/issues/6793#issuecomment-1706620272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new service `n8n-init` to handle directory ownership changes.

- **Updates**
  - Upgraded `n8n` version from `1.30.1` to `1.42.1`.
  - Added `N8N_SECURE_COOKIE` environment variable set to `false`.

- **Configuration Changes**
  - Updated `config.json` to reflect new `tipi_version`, `version`, and structured `supported_architectures` and `categories` as arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->