### PR TITLE
fix(invoice-ninja): db not healthy after restart

### DIFF
--- a/apps/invoice-ninja/config.json
+++ b/apps/invoice-ninja/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "invoice-ninja",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "5.8.57",
   "categories": ["finance"],
   "description": "Invoice Ninja is an invoicing application which makes sending invoices and receiving payments simple and easy. Our latest version is a clean slate rewrite of our popular invoicing application which builds on the existing feature set and adds a wide range of features and enhancements the community has asked for.",

--- a/apps/invoice-ninja/docker-compose.yml
+++ b/apps/invoice-ninja/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       - ${APP_DATA_DIR}/data/php/php.ini:/usr/local/etc/php/php.ini:ro
       - ${APP_DATA_DIR}/data/php/php-cli.ini:/usr/local/etc/php/php-cli.ini:ro
     depends_on:
-      invoice-ninja-db:
-        condition: service_healthy
+      - invoice-ninja-db
     networks:
       - tipi_main_network
 
@@ -85,12 +84,8 @@ services:
     depends_on:
       invoice-ninja-init:
         condition: service_completed_successfully
-    healthcheck:
-      test: ['CMD', 'healthcheck.sh', '--su-mysql', '--connect', '--innodb_initialized']
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+    # This command is required to set important mariadb defaults
+    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
 
   invoice-ninja-init:
     image: bash:5.2.26


### PR DESCRIPTION
After restart the mariadb is not healthy and report warnings

```
Access denied for user 'mysql'@'localhost' (using password: NO)
```

Now should work fine. At least is working locally to me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `docker-compose.yml` to simplify service dependencies and configurations.
  - Incremented `tipi_version` in `config.json` from 3 to 4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->