### PR TITLE
bitcoind: Use single dash for args and add more value options

### DIFF
--- a/apps/bitcoind/config.json
+++ b/apps/bitcoind/config.json
@@ -7,7 +7,7 @@
   "port": 8333,
   "id": "bitcoind",
   "description": "Bitcoin core node",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "27.0",
   "categories": [
     "finance"
@@ -16,6 +16,13 @@
   "author": "Bitcoin developers",
   "source": "https://github.com/lncm/docker-bitcoind",
   "form_fields": [
+    {
+      "type": "number",
+      "label": "Reduce storage requirements by enabling pruning (deleting) of old blocks",
+      "hint": "default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=550 = automatically prune block files to stay under the specified target size in MiB",
+      "required": false,
+      "env_variable": "BITCOIND_PRUNING"
+    },
     {
       "type": "number",
       "label": "DB Cache Size (In mb)",
@@ -36,6 +43,23 @@
       "hint": "Accept incoming connections from peers.",
       "required": false,
       "env_variable": "BITCOIND_LISTEN",
+      "options": [
+        {
+          "label": "Yes",
+          "value": "1"
+        },
+        {
+          "label": "No",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "label": "Accept JSON-RPC requests",
+      "hint": "Allows you to use bitcoin-cli to communicate with the node",
+      "required": false,
+      "env_variable": "BITCOIND_SERVER",
       "options": [
         {
           "label": "Yes",

--- a/apps/bitcoind/docker-compose.yml
+++ b/apps/bitcoind/docker-compose.yml
@@ -14,14 +14,16 @@ services:
     restart: unless-stopped
     stop_grace_period: 15m30s
     command: >-
-      --dbcache=${BITCOIND_DB_CACHE:-450}
-      --maxmempool=${BITCOIND_MAX_MEMPOOL:-300}
-      --listen=${BITCOIND_LISTEN:-0}
-      --maxconnections=${BITCOIND_MAXPEERS:-125}
-      --txindex=${BITCOIND_TXINDEX:-1}
-      --peerbloomfilters=${BITCOIND_BLOOM_FILTERS:-1}
-      --blockfilterindex=${BITCOIND_BLOCK_FILTER:-1}
-      --peerblockfilters=${BITCOIND_BLOCK_FILTER:-1}
+      -dbcache=${BITCOIND_DB_CACHE:-450}
+      -maxmempool=${BITCOIND_MAX_MEMPOOL:-300}
+      -listen=${BITCOIND_LISTEN:-0}
+      -server=${BITCOIND_SERVER:-0}
+      -prune=${BITCOIND_PRUNING:-0}
+      -maxconnections=${BITCOIND_MAXPEERS:-125}
+      -txindex=${BITCOIND_TXINDEX:-1}
+      -peerbloomfilters=${BITCOIND_BLOOM_FILTERS:-1}
+      -blockfilterindex=${BITCOIND_BLOCK_FILTER:-1}
+      -peerblockfilters=${BITCOIND_BLOCK_FILTER:-1}
     networks:
       - tipi_main_network
     labels:


### PR DESCRIPTION
See https://manpages.debian.org/testing/bitcoind/bitcoind.1.en.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a form field to enable pruning of old blocks, reducing storage requirements.
  - Added a form field to accept JSON-RPC requests, facilitating communication with the node using bitcoin-cli.

- **Improvements**
  - Updated command options in the `bitcoind` service to use short form (`-`) for parameters such as `dbcache`, `maxmempool`, `listen`, `server`, and `prune`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->