### PR TITLE
Fix windows | sysctl: permission denied on key "net.ipv4.ip_forward"

### DIFF
--- a/apps/windows/docker-compose.yml
+++ b/apps/windows/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - ${APP_DATA_DIR}/data/storage:/storage
     networks:
       - tipi_main_network
+    sysctls:
+      - net.ipv4.ip_forward=1
     labels:
       # Main
       traefik.enable: true


### PR DESCRIPTION
Fix windows | sysctl: permission denied on key "net.ipv4.ip_forward"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker configuration for Windows service to enhance network forwarding capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->