### PR TITLE
[App] [Bitcoind]: Listen for rpc calls by default

### DIFF
--- a/apps/bitcoind/config.json
+++ b/apps/bitcoind/config.json
@@ -7,7 +7,7 @@
   "port": 8333,
   "id": "bitcoind",
   "description": "Bitcoin core node",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "27.0",
   "categories": [
     "finance"

--- a/apps/bitcoind/docker-compose.yml
+++ b/apps/bitcoind/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       -dbcache=${BITCOIND_DB_CACHE:-450}
       -maxmempool=${BITCOIND_MAX_MEMPOOL:-300}
       -listen=${BITCOIND_LISTEN:-0}
-      -server=${BITCOIND_SERVER:-0}
+      -server=${BITCOIND_SERVER:-1}
       -prune=${BITCOIND_PRUNING:-0}
       -maxconnections=${BITCOIND_MAXPEERS:-125}
       -txindex=${BITCOIND_TXINDEX:-1}


### PR DESCRIPTION
If bitcoind dont start de rpc server, the .cookie file wont be generated so other apps like #3336 or #3434 will work by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled server functionality for the `bitcoind` service by updating the `-server` flag in `docker-compose.yml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->