### PR TITLE
[Bitcoind] Add rpc bind and allow for docker setup

### DIFF
--- a/apps/bitcoind/config.json
+++ b/apps/bitcoind/config.json
@@ -7,7 +7,7 @@
   "port": 8333,
   "id": "bitcoind",
   "description": "Bitcoin core node",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "27.0",
   "categories": [
     "finance"

--- a/apps/bitcoind/docker-compose.yml
+++ b/apps/bitcoind/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     command: >-
       -dbcache=${BITCOIND_DB_CACHE:-450}
       -maxmempool=${BITCOIND_MAX_MEMPOOL:-300}
-      -listen=${BITCOIND_LISTEN:-0}
+      -listen=${BITCOIND_LISTEN:-1}
       -server=${BITCOIND_SERVER:-1}
       -rpcallowip=0.0.0.0/0
       -rpcbind=0.0.0.0

--- a/apps/bitcoind/docker-compose.yml
+++ b/apps/bitcoind/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       -maxmempool=${BITCOIND_MAX_MEMPOOL:-300}
       -listen=${BITCOIND_LISTEN:-0}
       -server=${BITCOIND_SERVER:-1}
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
       -prune=${BITCOIND_PRUNING:-0}
       -maxconnections=${BITCOIND_MAXPEERS:-125}
       -txindex=${BITCOIND_TXINDEX:-1}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated `tipi_version` from 4 to 5 in the `bitcoind` app for improved functionality.
  - Enabled RPC server access from any IP address and bound RPC server to all network interfaces in the `bitcoind` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->