### PR TITLE
fix: update outline oidc provider to point to correct image

### DIFF
--- a/apps/outline/config.json
+++ b/apps/outline/config.json
@@ -9,7 +9,7 @@
     "utilities"
   ],
   "description": "Outline is a knowledge base designed for teams. It's goals are to be fast, intuitive and support many integrations.",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "0.75.2",
   "source": "https://github.com/outline/outline",
   "website": "https://getoutline.com",

--- a/apps/outline/docker-compose.yml
+++ b/apps/outline/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   outline-oidc:
     container_name: outline-oidc
-    image: ghcr.io/hex-developer/oidc-provider:v0.2.0
+    image: ghcr.io/sergi0g/oidc-provider:v0.2.0
     restart: unless-stopped
     environment:
       - LANGUAGE_CODE=en-us


### PR DESCRIPTION
I just changed my GitHub username and since Outline relies on a container which is linked to it, I wanted to update Outline's docker-compose to reflect the change. Current Outline installs shouldn't be affected, but any new attempts will fail unless the URL is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker image repository for `outline-oidc` service.
  - Updated `tipi_version` in configuration to version 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->