### PR TITLE
refactor(netbootxyz): use official image

### DIFF
--- a/apps/netbootxyz/config.json
+++ b/apps/netbootxyz/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "id": "netbootxyz",
   "description": "Your favorite operating systems in one place. A network-based bootable operating system installer based on iPXE.",
-  "tipi_version": 2,
-  "version": "2.0.53",
+  "tipi_version": 3,
+  "version": "0.7.1-nbxyz3",
   "categories": [
     "utilities"
   ],

--- a/apps/netbootxyz/docker-compose.yml
+++ b/apps/netbootxyz/docker-compose.yml
@@ -1,13 +1,14 @@
-version: "3.7"
+version: "3.9"
 services:
   netbootxyz:
-    image: lscr.io/linuxserver/netbootxyz:2.0.53
+    image: netbootxyz/netbootxyz:0.7.1-nbxyz3
     container_name: netbootxyz
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${APP_DATA_DIR}/data/assets:/assets
     ports:
       - ${APP_PORT}:3000
+      - 8676:8080
       - 69:69/udp
     restart: unless-stopped
     networks:
@@ -37,4 +38,5 @@ services:
       traefik.http.routers.netbootxyz-local.entrypoints: websecure
       traefik.http.routers.netbootxyz-local.service: netbootxyz
       traefik.http.routers.netbootxyz-local.tls: true
+      # Runtipi managed
       runtipi.managed: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Docker image version for `netbootxyz` to `0.7.1-nbxyz3`.
  - Added new port mappings: `8676:8080` and `69:69/udp`.
  - Added comment indicating management by Runtipi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->