### PR TITLE
fix(whisparr): bump version

### DIFF
--- a/apps/whisparr/config.json
+++ b/apps/whisparr/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 6969,
   "id": "whisparr",
-  "tipi_version": 2,
-  "version": "nightly-2.0.0.313",
+  "tipi_version": 3,
+  "version": "nightly-2.0.0.548",
   "categories": [
     "media",
     "utilities"

--- a/apps/whisparr/docker-compose.yml
+++ b/apps/whisparr/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   whisparr:
     container_name: whisparr
     hostname: ${APP_ID}
-    image: ghcr.io/hotio/whisparr:nightly-2.0.0.313
+    image: ghcr.io/hotio/whisparr:nightly-2.0.0.548
     ports:
       - "${APP_PORT}:6969"
     environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `whisparr` app to use `tipi_version` 3.
  - Upgraded `whisparr` app version from "nightly-2.0.0.313" to "nightly-2.0.0.548".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->