### PR TITLE
[APP] pinchflat - changed image tag to v2024.6.25

### DIFF
--- a/apps/pinchflat/config.json
+++ b/apps/pinchflat/config.json
@@ -5,8 +5,8 @@
   "available": true,
   "exposable": true,
   "id": "pinchflat",
-  "tipi_version": 3,
-  "version": "0.1.18",
+  "tipi_version": 4,
+  "version": "v2024.6.25",
   "categories": [
     "media"
   ],

--- a/apps/pinchflat/docker-compose.yml
+++ b/apps/pinchflat/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pinchflat:
-    image: keglin/pinchflat:v0.1.18
+    image: keglin/pinchflat:v2024.6.25
     container_name: pinchflat
     environment:
       - BASIC_AUTH_USERNAME=${PINCHFLAT_BASIC_AUTH_USERNAME}


### PR DESCRIPTION
- pinchflat changed versioning
- updated to v2024.6.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated service configuration to use the latest version (`v2024.6.25`) of the `pinchflat` application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->