### PR TITLE
Fix the netbootxyz traefik loadbalancer server port

### DIFF
--- a/apps/netbootxyz/docker-compose.yml
+++ b/apps/netbootxyz/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # Main
       traefik.enable: true
       traefik.http.middlewares.netbootxyz-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.netbootxyz.loadbalancer.server.port: 19999
+      traefik.http.services.netbootxyz.loadbalancer.server.port: 3000
       # Web
       traefik.http.routers.netbootxyz-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.netbootxyz-insecure.entrypoints: web


### PR DESCRIPTION
The netbootxyz web ui runs on port 3000 inside the container. Currently traefik is trying to use port 19999 which results in a 500 internal server error when trying to access the netbootxyz web ui via `netbootxyz.${LOCAL_DOMAIN}`. 

This PR changes the traefik loadbalancer server port to the correct port.