### PR TITLE
fix(heimdall): https port fixed

### DIFF
--- a/apps/heimdall/docker-compose.yml
+++ b/apps/heimdall/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   heimdall:
     image: lscr.io/linuxserver/heimdall:2.6.1
@@ -19,7 +17,7 @@ services:
       # Main
       traefik.enable: true
       traefik.http.middlewares.heimdall-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.heimdall.loadbalancer.server.port: 3000
+      traefik.http.services.heimdall.loadbalancer.server.port: 80
       # Web
       traefik.http.routers.heimdall-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.heimdall-insecure.entrypoints: web


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Heimdall service configuration to improve accessibility by changing the server port to the standard HTTP port (80).
  
- **Chores**
  - Removed the version specification from the configuration for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->