### PR TITLE
Update Nextcloud to 27.1.11

### DIFF
--- a/apps/nextcloud/config.json
+++ b/apps/nextcloud/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8083,
   "id": "nextcloud",
-  "tipi_version": 23,
-  "version": "26.0.13-apache",
+  "tipi_version": 24,
+  "version": "27.1.11-apache",
   "categories": [
     "data"
   ],

--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   nextcloud:
     container_name: nextcloud
-    image: nextcloud:26.0.13-apache
+    image: nextcloud:27.1.1-apache
     restart: unless-stopped
     ports:
       - ${APP_PORT}:80
@@ -71,7 +71,7 @@ services:
     labels:
       runtipi.managed: true
   cron:
-    image: nextcloud:25.0.13-apache
+    image: nextcloud:27.1.11-apache
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data/nextcloud:/var/www/html


### PR DESCRIPTION
We cannot upgrade directly to the current major version (29). It has to be a bit by bit update. So for now 27 and then I will provide an update to 28 in a week.