### PR TITLE
[fix]speedtest tracker

### DIFF
--- a/apps/speedtest-tracker/config.json
+++ b/apps/speedtest-tracker/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "speedtest-tracker",
-  "tipi_version": 39,
+  "tipi_version": 40,
   "version": "0.21.2",
   "categories": ["utilities"],
   "description": "Speedtest Tracker is a self-hosted internet performance tracking application that runs speedtest checks against Ookla's Speedtest service.",
@@ -18,6 +18,36 @@
       "label": "SPEEDTEST_TRACKER_DB_PASSWORD",
       "min": 32,
       "env_variable": "SPEEDTEST_TRACKER_DB_PASSWORD"
+    },
+    {
+      "type": "text",
+      "label": "Application Key",
+      "env_variable": "SPEEDTEST_APP_KEY",
+      "min": 51,
+      "max": 51,
+      "default": "",
+      "required": true,
+      "hint": "Generate an app key at https://speedtest-tracker.dev/"
+    },
+    {
+      "type": "text",
+      "label": "Speedtest Schedule (cron format)",
+      "env_variable": "SPEEDTEST_SCHEDULE",
+      "default": "30 * * * *",
+      "min": 9,
+      "max": 100,
+      "required": true,
+      "hint": "https://crontab.guru is a good resource"
+    },
+    {
+      "type": "text",
+      "label": "Speedtest Servers (comma-separated IDs)",
+      "env_variable": "SPEEDTEST_SERVERS",
+      "default": "",
+      "min": 6,
+      "max": 100,
+      "required": true,
+      "hint": "Convenient-to-you speedtest servers may be found at https://speedtest.net/speedtest-servers-static.php"
     }
   ],
   "supported_architectures": ["arm64", "amd64"],

--- a/apps/speedtest-tracker/docker-compose.yml
+++ b/apps/speedtest-tracker/docker-compose.yml
@@ -13,7 +13,12 @@ services:
       - DB_DATABASE=speedtest-tracker
       - DB_USERNAME=tipi
       - DB_PASSWORD=${SPEEDTEST_TRACKER_DB_PASSWORD}
+      - SPEEDTEST_SCHEDULE=${SPEEDTEST_SCHEDULE:-'30 * * * *'} # every half-hour
+      - SPEEDTEST_SERVERS=${SPEEDTEST_SERVERS:-''}
       - TZ=${TZ}
+      - APP_TIMEZONE=${TZ}
+      - DISPLAY_TIMEZONE=${TZ}
+      - APP_KEY=${SPEEDTEST_APP_KEY}
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data/speedtest-tracker/config:/config

--- a/apps/speedtest-tracker/metadata/description.md
+++ b/apps/speedtest-tracker/metadata/description.md
@@ -4,7 +4,7 @@ Speedtest Tracker is a self-hosted internet performance tracking application tha
 
 ## About
 
-![](https://F3367574858-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fvtb3s6TB12XY9iIx8YyJ%2Fuploads%2Fgit-blob-2896fa80b8d3f90cc8c4c495b8b9793af5f62244%2Fimage%20(2).png?alt=media&width=768&dpr=4&quality=100&sign=d549885e&sv=1)
+![v0.20.6 Speedtest Tracker Dashboard](https://F3367574858-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fvtb3s6TB12XY9iIx8YyJ%4Fuploads%2Fgit-blob-2896fa80b8d3f90cc8c4c495b8b9793af5f62244%2Fimage%20(2).png?alt=media&width=768&dpr=4&quality=100&sign=d549885e&sv=1)
 
 A self-hosted app to check your internet speed using Ookla's Speedtest service and track its history. Built using Laravel and the Speedtest CLI.
 
@@ -33,17 +33,17 @@ This is the password for the PostgreSQL database used by Speedtest Tracker. It's
 
 ### SPEEDTEST_APP_KEY
 
-This is the application key used by Laravel for encryption and other security features. You can retrieve one at https://speedtest-tracker.dev
+This is the application key used by Laravel for encryption and other security features. You can retrieve one at the [Speedtest Tracker](https://speedtest-tracker.dev) site.
 
 ### SPEEDTEST_SCHEDULE (cron format)
 
-This field allows you to set the schedule for running speed tests. It uses cron syntax. The default value is `30 * * * *`, which runs a test every 30 minutes. You can adjust this to your preferred frequency. https://crontab.guru is a good resource.
+This field allows you to set the schedule for running speed tests. It uses cron syntax. The default value is `30 * * * *`, which runs a test every 30 minutes. You can adjust this to your preferred frequency. [Crontab Guru](https://crontab.guru) is a good resource.
 
 ### SPEEDTEST_SERVERS (comma-separated IDs)
 
 Specify Speedtest servers to use for your tests. Enter one or more server IDs, separated by commas. To find server IDs, you can use the following method:
 
-1. Open your web browser and navigate to: https://www.speedtest.net/speedtest-servers.php
+1. Open your web browser and navigate to [Speedtest.net's Servers page](https://www.speedtest.net/speedtest-servers.php)
 2. This page will display a list of Speedtest servers along with their IDs, names, sponsors, and locations.
 3. Find the server(s) you want to use and note down their IDs.
 4. Enter these IDs in the Speedtest Servers field, separated by commas (e.g., "1234,5678,9012").

--- a/apps/speedtest-tracker/metadata/description.md
+++ b/apps/speedtest-tracker/metadata/description.md
@@ -1,5 +1,22 @@
+# Speedtest Tracker
 
-## Authentication
+Speedtest Tracker is a self-hosted internet performance tracking application that runs speedtest checks against Ookla's Speedtest service.
+
+## About
+
+![](https://F3367574858-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fvtb3s6TB12XY9iIx8YyJ%2Fuploads%2Fgit-blob-2896fa80b8d3f90cc8c4c495b8b9793af5f62244%2Fimage%20(2).png?alt=media&width=768&dpr=4&quality=100&sign=d549885e&sv=1)
+
+A self-hosted app to check your internet speed using Ookla's Speedtest service and track its history. Built using Laravel and the Speedtest CLI.
+
+The main use case for Speedtest Tracker is to build a history of your internet's performance so that you can be informed when you're not receiving your ISP's advertised rates.
+
+_...also some of us just like a lot of data._
+
+These docs are up-to-date for version: `v0.21.2`
+
+## Configuration
+
+### Authentication
 
 Speedtest Tracker uses Filament for the admin panel. During the install process an admin account is created for you.
 
@@ -10,23 +27,24 @@ Default User Account
 
 ---
 
-## About
+### SPEEDTEST_TRACKER_DB_PASSWORD
 
-A Docker image to check your internet speed using Ookla's Speedtest service. Build using Laravel and the Speedtest CLI.
-These docs are up-to-date for version: `v0.12.1`
+This is the password for the PostgreSQL database used by Speedtest Tracker. It's automatically generated and should be a secure, random string of at least 32 characters.
 
-![](https://834071469-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2Fvtb3s6TB12XY9iIx8YyJ%2Fuploads%2FrOKoxV0cH35wwjkbAgvE%2Fdashboard_screenshot.jpg?alt=media&token=121f5175-4008-4b26-9655-bc67d1369710)
+### SPEEDTEST_APP_KEY
 
-### 
+This is the application key used by Laravel for encryption and other security features. You can retrieve one at https://speedtest-tracker.dev
 
-Introduction
+### SPEEDTEST_SCHEDULE (cron format)
 
-Speedtest Tracker is a self-hosted internet performance tracking application that runs speedtest checks against Ookla's Speedtest service.
+This field allows you to set the schedule for running speed tests. It uses cron syntax. The default value is `30 * * * *`, which runs a test every 30 minutes. You can adjust this to your preferred frequency. https://crontab.guru is a good resource.
 
-#### 
+### SPEEDTEST_SERVERS (comma-separated IDs)
 
-Why might I want this?
+Specify Speedtest servers to use for your tests. Enter one or more server IDs, separated by commas. To find server IDs, you can use the following method:
 
-The main use case for Speedtest Tracker is to build a history of your internet's performance so that you can be informed when you're not receiving your ISP's advertised rates.
+1. Open your web browser and navigate to: https://www.speedtest.net/speedtest-servers.php
+2. This page will display a list of Speedtest servers along with their IDs, names, sponsors, and locations.
+3. Find the server(s) you want to use and note down their IDs.
+4. Enter these IDs in the Speedtest Servers field, separated by commas (e.g., "1234,5678,9012").
 
-_...also some of us just like a lot of data._


### PR DESCRIPTION
As of v0.20, Speedtest Tracker removed config for server and schedule settings out of the UI and into env var, and also stopped autogenerating (sharing? I'm not completely sure) the app key, moving it to an env var as well. This made the current Tipi config unable to boot and without any easy guidance on how to fix it.

This puts the newly-required env vars into the compose file and config.json with some docs and pointers about how to collect them. The automated version i mentioned in Discord ended up being way too hacky.

FWIW I also ran into issues with a bad config.json that a) seemed to pass schema.json validation and b) at first generated no visible error messages - just removed the app from the custom app store. I might look at updating the schema; i suspect the lack of logs had to do with container / image mishmashing while i was working on the fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new configuration parameters for enhanced application flexibility, including Application Key, Speedtest Schedule, and Speedtest Servers.
  
- **Bug Fixes**
	- Updated the application version for improved performance and stability.

- **Documentation**
	- Expanded documentation to provide clearer descriptions of the application and detailed configuration options, enhancing user understanding and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->