### PR TITLE
fix: remove quotes and add credentials to Planka

### DIFF
--- a/apps/planka/docker-compose.yml
+++ b/apps/planka/docker-compose.yml
@@ -22,8 +22,12 @@ services:
     environment:
       - BASE_URL=${APP_PROTOCOL:-http}://${APP_DOMAIN}
       - TRUST_PROXY=1
-      - DATABASE_URL="postgresql://postgres@postgres/planka"
-      - SECRET_KEY="${PLANKA_SECRET_KEY}"
+      - DATABASE_URL=postgresql://postgres@postgres/planka
+      - SECRET_KEY=${PLANKA_SECRET_KEY}
+      - DEFAULT_ADMIN_EMAIL=demo@demo.demo
+      - DEFAULT_ADMIN_PASSWORD=demo
+      - DEFAULT_ADMIN_NAME=Demo Demo
+      - DEFAULT_ADMIN_USERNAME=demo
     networks:
       - tipi_main_network
     labels:


### PR DESCRIPTION
Quotes were included the environment variable which caused the Planka to fail to boot up with a `getaddrinfo EAI_AGAIN base` error. I'm not a node.js expert, but it seemed to be happening when knex was trying to connect to the database to apply migrations.

Planka seems to not create the default admin unless it's specified so I copied the lines from
https://github.com/plankanban/planka/blob/master/docker-compose.yml. I think it would be better to allow the user to specify their own email/username/name/password in Tipi since I don't see a way to edit the admin credentials when I log in, but the `demo@demo.demo / demo` is in the app description, so at least this gets the app running.

After these changes, I was able to boot Planka from Tipi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new environment variables for default administrative credentials, streamlining the initial setup process.
- **Configuration Changes**
	- Updated the format of existing environment variables to improve their interpretation by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->