### PR TITLE
fix(wg-easy): update env variable

### DIFF
--- a/apps/wg-easy/docker-compose.yml
+++ b/apps/wg-easy/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ${APP_PORT}:51821/tcp
     environment:
       WG_HOST: "${WIREGUARD_HOST}"
-      PASSWORD: "${WIREGUARD_PASSWORD}"
+      PASSWORD_HASH: "${WIREGUARD_PASSWORD}"
       WG_DEFAULT_DNS: "${WIREGUARD_DNS:-8.8.8.8}"
       WG_ALLOWED_IPS: 0.0.0.0/0, ::/0
     cap_add:


### PR DESCRIPTION
update docker-compose.yml to include new PASSWORD_HASH environment variable as per the new wg-easy docker image requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
	- Updated the handling of sensitive information by renaming the `PASSWORD` variable to `PASSWORD_HASH`, improving security by utilizing hashed passwords instead of plaintext.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->