### PR TITLE
Make Dashy exposable

### DIFF
--- a/apps/dashy/config.json
+++ b/apps/dashy/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "dashy",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "3.1.0",
   "categories": ["utilities"],
   "description": "A self-hostable personal dashboard built for you. Includes status-checking, widgets, themes, icon packs, a UI editor and tons more!",
@@ -15,5 +15,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1729089865613
 }

--- a/apps/dashy/config.json
+++ b/apps/dashy/config.json
@@ -3,7 +3,7 @@
   "name": "Dashy",
   "port": 8205,
   "available": true,
-  "exposable": false,
+  "exposable": true,
   "id": "dashy",
   "tipi_version": 5,
   "version": "3.1.0",


### PR DESCRIPTION
Dashy should be able to be exposed. If a user wants to protect Dashy, they can use [Dashy's built-in authentication](https://dashy.to/docs/authentication).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The Dashy application is now accessible with updated exposure settings, enhancing its usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->