### PR TITLE
Fix immich port 3001 -> 2283

### DIFF
--- a/apps/immich/config.json
+++ b/apps/immich/config.json
@@ -5,7 +5,7 @@
   "exposable": true,
   "port": 8128,
   "id": "immich",
-  "tipi_version": 108,
+  "tipi_version": 109,
   "version": "1.118.2",
   "categories": ["data", "photography"],
   "description": "Photo and video backup solution directly from your mobile phone.",
@@ -35,5 +35,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1729322150000
+  "updated_at": 1729330622000
 }

--- a/apps/immich/docker-compose.yml
+++ b/apps/immich/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - immich-redis
       - immich-db
     ports:
-      - ${APP_PORT}:3001
+      - ${APP_PORT}:2283
     restart: unless-stopped
     networks:
       - tipi_main_network
@@ -27,7 +27,7 @@ services:
       # Main
       traefik.enable: true
       traefik.http.middlewares.immich-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.immich.loadbalancer.server.port: 3001
+      traefik.http.services.immich.loadbalancer.server.port: 2283
       # Web
       traefik.http.routers.immich-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.immich-insecure.entrypoints: web


### PR DESCRIPTION
Fix Immich internal port to reflect the new assigned port in 1.118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated port mapping for the Immich service from `3001` to `2283`, enhancing service accessibility.
  
- **Bug Fixes**
	- Adjusted Traefik load balancer configuration to reflect the new port for improved routing.

- **Chores**
	- Incremented `tipi_version` from 108 to 109 in the configuration file, indicating an update in the versioning scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->