### PR TITLE
Add dynamic compose for archivebox

### DIFF
--- a/apps/archivebox/config.json
+++ b/apps/archivebox/config.json
@@ -1,37 +1,38 @@
 {
-  "$schema": "../schema.json",
-  "name": "ArchiveBox",
-  "available": true,
-  "exposable": true,
-  "port": 8015,
-  "id": "archivebox",
-  "tipi_version": 4,
-  "version": "0.7.2",
-  "categories": ["media"],
-  "description": "ArchiveBox is a powerful, self-hosted internet archiving solution to collect, save, and view websites offline.",
-  "short_desc": "Open source self-hosted web archiving.",
-  "author": "archivebox",
-  "source": "https://github.com/ArchiveBox/ArchiveBox",
-  "website": "https://archivebox.io",
-  "form_fields": [
-    {
-      "type": "text",
-      "label": "ArchiveBox Username",
-      "max": 50,
-      "min": 3,
-      "required": true,
-      "env_variable": "ARCHIVEBOX_USERNAME"
-    },
-    {
-      "type": "password",
-      "label": "ArchiveBox Password",
-      "max": 50,
-      "min": 12,
-      "required": true,
-      "env_variable": "ARCHIVEBOX_PASSWORD"
-    }
-  ],
-  "supported_architectures": ["arm64", "amd64"],
-  "created_at": 1691943801422,
-  "updated_at": 1723566285000
+    "$schema": "../schema.json",
+    "name": "ArchiveBox",
+    "available": true,
+    "exposable": true,
+    "dynamic_config": true,
+    "port": 8015,
+    "id": "archivebox",
+    "tipi_version": 5,
+    "version": "0.7.2",
+    "categories": [ "media" ],
+    "description": "ArchiveBox is a powerful, self-hosted internet archiving solution to collect, save, and view websites offline.",
+    "short_desc": "Open source self-hosted web archiving.",
+    "author": "archivebox",
+    "source": "https://github.com/ArchiveBox/ArchiveBox",
+    "website": "https://archivebox.io",
+    "form_fields": [
+        {
+            "type": "text",
+            "label": "ArchiveBox Username",
+            "max": 50,
+            "min": 3,
+            "required": true,
+            "env_variable": "ARCHIVEBOX_USERNAME"
+        },
+        {
+            "type": "password",
+            "label": "ArchiveBox Password",
+            "max": 50,
+            "min": 12,
+            "required": true,
+            "env_variable": "ARCHIVEBOX_PASSWORD"
+        }
+    ],
+    "supported_architectures": [ "arm64", "amd64" ],
+    "created_at": 1691943801422,
+    "updated_at": 1729872551916
 }

--- a/apps/archivebox/docker-compose.json
+++ b/apps/archivebox/docker-compose.json
@@ -1,0 +1,35 @@
+{
+    "services": [
+        {
+            "name": "archivebox",
+            "image": "archivebox/archivebox:0.7.2",
+            "isMain": true,
+            "internalPort": 8015,
+            "restart": "unless-stopped",
+            "environment": {
+                "PORT": "8015",
+                "PUBLIC_INDEX": "${ARCHIVEBOX_PUBLIC_INDEX-true}",
+                "PUBLIC_SNAPSHOTS": "${ARCHIVEBOX_PUBLIC_SNAPSHOTS-true}",
+                "PUBLIC_ADD_VIEW": "${ARCHIVEBOX_PUBLIC_ADD_VIEW-false}",
+                "ADMIN_USERNAME": "${ARCHIVEBOX_USERNAME}",
+                "ADMIN_PASSWORD": "${ARCHIVEBOX_PASSWORD}",
+                "PUID": "1000",
+                "PGID": "1000",
+                "SEARCH_BACKEND_ENGINE": "${ARCHIVEBOX_SEARCH_BACKEND_ENGINE}",
+                "SEARCH_BACKEND_HOST_NAME": "${ARCHIVEBOX_SEARCH_BACKEND_HOST_NAME}",
+                "SEARCH_BACKEND_PASSWORD": "${ARCHIVEBOX_SEARCH_BACKEND_PASSWORD}",
+                "MEDIA_MAX_SIZE": "${ARCHIVEBOX_MEDIA_MAX_SIZE-750m}",
+                "TIMEOUT": "${ARCHIVEBOX_TIMEOUT-60}",
+                "CHECK_SSL_VALIDITY": "${ARCHIVEBOX_CHECK_SSL_VALIDITY-true}",
+                "SAVE_ARCHIVE_DOT_ORG": "${ARCHIVEBOX_SAVE_ARCHIVE_DOT_ORGE-true}"
+            },
+            "volumes": [
+                {
+                    "hostPath": "${APP_DATA_DIR}/data",
+                    "containerPath": "/data"
+                }
+            ],
+            "command": "server --quick-init 0.0.0.0:8015"
+        }
+    ]
+}


### PR DESCRIPTION
## Dynamic compose for archivebox
This is a archivebox update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 🗄 Archive a webpage
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/data
##### Specific instructions verified :
- [x] 🌳 Environment (too much too list here)
- [x] 💻 Command (server --quick-init 0.0.0.0:8015)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Docker Compose configuration for the ArchiveBox service, enabling easier deployment and management.
	- Added a dynamic configuration option, enhancing flexibility in configuration handling.
  
- **Updates**
	- Updated the `tipi_version` to indicate an upgrade in the configuration schema.
	- Modified timestamps to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->