### PR TITLE
Add dynamic compose for dailytxt

### DIFF
--- a/apps/dailytxt/config.json
+++ b/apps/dailytxt/config.json
@@ -22,7 +22,7 @@
         },
         {
             "type": "boolean",
-            "label": "Allow User Registrastion",
+            "label": "Allow User Registration",
             "hint": "Set it to true intially to create the first user.",
             "placeholder": "true",
             "default": true,

--- a/apps/dailytxt/config.json
+++ b/apps/dailytxt/config.json
@@ -1,34 +1,35 @@
 {
-  "$schema": "../schema.json",
-  "name": "DailyTxT",
-  "port": 8156,
-  "available": true,
-  "exposable": true,
-  "id": "dailytxt",
-  "tipi_version": 7,
-  "version": "1.0.15",
-  "categories": ["utilities"],
-  "description": "DailyTxT is an encrypted Diary Web-App to write down your stories of the day and to find them again easily.",
-  "short_desc": "Encrypted Diary Web-App",
-  "author": "PhiTux",
-  "source": "https://github.com/PhiTux/DailyTxT",
-  "form_fields": [
-    {
-      "type": "random",
-      "label": "DailyTXT Secret Key",
-      "min": 32,
-      "env_variable": "DAILYTXT_SECRET_KEY"
-    },
-    {
-      "type": "boolean",
-      "label": "Allow User Registrastion",
-      "hint": "Set it to true intially to create the first user.",
-      "placeholder": "true",
-      "default": true,
-      "env_variable": "DAILYTXT_ALLOW_REGISTRATION"
-    }
-  ],
-  "supported_architectures": ["arm64", "amd64"],
-  "created_at": 1691943801422,
-  "updated_at": 1723566284000
+    "$schema": "../schema.json",
+    "name": "DailyTxT",
+    "port": 8156,
+    "available": true,
+    "exposable": true,
+    "dynamic_config": true,
+    "id": "dailytxt",
+    "tipi_version": 8,
+    "version": "1.0.15",
+    "categories": [ "utilities" ],
+    "description": "DailyTxT is an encrypted Diary Web-App to write down your stories of the day and to find them again easily.",
+    "short_desc": "Encrypted Diary Web-App",
+    "author": "PhiTux",
+    "source": "https://github.com/PhiTux/DailyTxT",
+    "form_fields": [
+        {
+            "type": "random",
+            "label": "DailyTXT Secret Key",
+            "min": 32,
+            "env_variable": "DAILYTXT_SECRET_KEY"
+        },
+        {
+            "type": "boolean",
+            "label": "Allow User Registrastion",
+            "hint": "Set it to true intially to create the first user.",
+            "placeholder": "true",
+            "default": true,
+            "env_variable": "DAILYTXT_ALLOW_REGISTRATION"
+        }
+    ],
+    "supported_architectures": [ "arm64", "amd64" ],
+    "created_at": 1691943801422,
+    "updated_at": 1729872627089
 }

--- a/apps/dailytxt/docker-compose.json
+++ b/apps/dailytxt/docker-compose.json
@@ -1,0 +1,25 @@
+{
+    "services": [
+        {
+            "name": "dailytxt",
+            "image": "phitux/dailytxt:1.0.15",
+            "isMain": true,
+            "internalPort": 8765,
+            "restart": "unless-stopped",
+            "environment": {
+                "PORT": "8765",
+                "SECRET_KEY": "${DAILYTXT_SECRET_KEY}",
+                "ALLOW_REGISTRATION": "${DAILYTXT_ALLOW_REGISTRATION}",
+                "DATA_INDENT": "2",
+                "JWT_EXP_DAYS": "60",
+                "ENABLE_UPDATE_CHECK": "True"
+            },
+            "volumes": [
+                {
+                    "hostPath": "${APP_DATA_DIR}/data/dailytxt",
+                    "containerPath": "/app/data/"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Dynamic compose for dailytxt
This is a dailytxt update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register and create entries
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/dailytxt:/app/data/
##### Specific instructions verified :
- [x] 🌳 Environment (too many to list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Docker Compose configuration for the DailyTxT service, enabling easy deployment and management.
	- Added a dynamic configuration option to enhance how settings are handled within the application.

- **Updates**
	- Incremented the version number to indicate an update in the application's configuration.
	- Updated the timestamp to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->