### PR TITLE
Fix Affine DB healthcheck

### DIFF
--- a/apps/affine/docker-compose.yml
+++ b/apps/affine/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U affine" ]
+      test: [ "CMD-SHELL", "pg_isready -d postgres://tipi:${AFFINE_POSTGRES_PASSWORD}@affine-postgres:5432/affine" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
(initially reported by @tsagadar in runtipi/runtipi#1732)

The healthcheck script for the database in Affine wasn't correct and caused the logs to be filled with lines saying `affine-postgres  | 2024-10-27 12:21:11.233 UTC [94] FATAL:  role "affine" does not exist`.

This issue occurs because the database user should be `tipi` and not `affine`. However, changing that also requires the database name to be specified, since more errors occur.

This PR fixes it by including the proper database connection string in the healthcheck, so no errors related to usernames and database names occur in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the health check command for the PostgreSQL service to ensure it accurately verifies the connection to the correct database with the appropriate credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->