### PR TITLE
Dynamic compose for spacedrive (and persistent storage)

### DIFF
--- a/apps/spacedrive/config.json
+++ b/apps/spacedrive/config.json
@@ -1,37 +1,38 @@
 {
-  "$schema": "../schema.json",
-  "name": "Spacedrive",
-  "available": true,
-  "exposable": true,
-  "port": 9300,
-  "id": "spacedrive",
-  "tipi_version": 5,
-  "version": "0.4.2",
-  "categories": ["utilities"],
-  "description": "Spacedrive is an open source cross-platform file explorer, powered by a virtual distributed filesystem written in Rust.",
-  "short_desc": "Cross-platform file explorer",
-  "author": "spacedriveapp",
-  "source": "https://github.com/spacedriveapp/spacedrive",
-  "website": "https://spacedrive.com/",
-  "form_fields": [
-    {
-      "type": "text",
-      "label": "Spacedrive Username",
-      "max": 50,
-      "min": 3,
-      "required": true,
-      "env_variable": "SD_AUTH_USER"
-    },
-    {
-      "type": "password",
-      "label": "Spacedrive Password",
-      "max": 50,
-      "min": 12,
-      "required": true,
-      "env_variable": "SD_AUTH_PASSWORD"
-    }
-  ],
-  "supported_architectures": ["arm64", "amd64"],
-  "created_at": 1691943801422,
-  "updated_at": 1724015728000
+    "$schema": "../schema.json",
+    "name": "Spacedrive",
+    "available": true,
+    "exposable": true,
+    "dynamic_config": true,
+    "port": 9300,
+    "id": "spacedrive",
+    "tipi_version": 6,
+    "version": "0.4.2",
+    "categories": [ "utilities" ],
+    "description": "Spacedrive is an open source cross-platform file explorer, powered by a virtual distributed filesystem written in Rust.",
+    "short_desc": "Cross-platform file explorer",
+    "author": "spacedriveapp",
+    "source": "https://github.com/spacedriveapp/spacedrive",
+    "website": "https://spacedrive.com/",
+    "form_fields": [
+        {
+            "type": "text",
+            "label": "Spacedrive Username",
+            "max": 50,
+            "min": 3,
+            "required": true,
+            "env_variable": "SD_AUTH_USER"
+        },
+        {
+            "type": "password",
+            "label": "Spacedrive Password",
+            "max": 50,
+            "min": 12,
+            "required": true,
+            "env_variable": "SD_AUTH_PASSWORD"
+        }
+    ],
+    "supported_architectures": [ "arm64", "amd64" ],
+    "created_at": 1691943801422,
+    "updated_at": 1729872871646
 }

--- a/apps/spacedrive/docker-compose.json
+++ b/apps/spacedrive/docker-compose.json
@@ -1,0 +1,20 @@
+{
+    "services": [
+        {
+            "name": "spacedrive",
+            "image": "ghcr.io/spacedriveapp/spacedrive/server:0.4.2",
+            "isMain": true,
+            "internalPort": 8080,
+            "restart": "unless-stopped",
+            "environment": {
+                "SD_AUTH": "${SD_AUTH_USER}:${SD_AUTH_PASSWORD}"
+            },
+            "volumes": [
+                {
+                    "hostPath": "${APP_DATA_DIR}/data/spacedrive",
+                    "containerPath": "/var/spacedrive"
+                }
+            ]
+        }
+    ]
+}

--- a/apps/spacedrive/docker-compose.json
+++ b/apps/spacedrive/docker-compose.json
@@ -13,6 +13,10 @@
                 {
                     "hostPath": "${APP_DATA_DIR}/data/spacedrive",
                     "containerPath": "/var/spacedrive"
+                },
+                {
+                    "hostPath": "${APP_DATA_DIR}/data/libraries",
+                    "containerPath": "/data/libraries"
                 }
             ]
         }


### PR DESCRIPTION
## Dynamic compose for spacedrive
This is a spacedrive update for using dynamic compose.
I also added a volume to store libraries
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 🌆 Retrieve data from /var/spacedrive
    - [x] 🔄 Check data after restart _(okay with new volume)_
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/spacedrive:/var/spacedrive
- [x] ${APP_DATA_DIR}/data/libraries:/data/libraries **(newly added)**
##### Specific instructions verified :
- [x] 🌳 Environment (SD_AUTH=${SD_AUTH_USER}:${SD_AUTH_PASSWORD})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Docker Compose configuration for the Spacedrive service, enabling easier deployment and management.
	- Added dynamic configuration support with the new property `"dynamic_config": true` in the application settings.

- **Updates**
	- Incremented the configuration version from 5 to 6, indicating an update in the schema.
	- Updated timestamps for recent changes in the configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->