### PR TITLE
Add dynamic compose for barrage

### DIFF
--- a/apps/barrage/config.json
+++ b/apps/barrage/config.json
@@ -4,8 +4,9 @@
   "port": 8145,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "barrage",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "0.3.0",
   "categories": ["utilities"],
   "description": "Minimal Deluge WebUI with full mobile support",
@@ -43,5 +44,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1731851733794
 }

--- a/apps/barrage/docker-compose.json
+++ b/apps/barrage/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "barrage",
+      "image": "maulik9898/barrage:0.3.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "NEXTAUTH_SECRET": "${NEXTAUTH_SECRET}",
+        "DELUGE_URL": "${DELUGE_URL}",
+        "DELUGE_PASSWORD": "${DELUGE_PASSWORD}",
+        "BARRAGE_PASSWORD": "${BARRAGE_PASSWORD}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for barrage
This is a barrage update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Connect to Deluge (http://deluge:8112)
  - [x] 🌊 Check/Add torrents into Deluge
##### Volumes mapping verified :
No volume
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support for the Barrage application.
	- Added a new Docker Compose configuration for the Barrage service, enabling easier deployment and management.

- **Updates**
	- Updated the framework version for the Barrage application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->