### PR TITLE
Dynamic compose/deluge

### DIFF
--- a/apps/deluge/config.json
+++ b/apps/deluge/config.json
@@ -4,8 +4,9 @@
   "port": 8144,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "deluge",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "2.1.1",
   "categories": ["utilities"],
   "description": "Deluge is a lightweight, Free Software, cross-platform BitTorrent client.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1731851758940
 }

--- a/apps/deluge/docker-compose.json
+++ b/apps/deluge/docker-compose.json
@@ -9,7 +9,7 @@
         {
           "hostPort": 6881,
           "containerPort": 6881,
-          "tcp": true
+          "tcp": true,
           "udp": true
         }
       ],

--- a/apps/deluge/docker-compose.json
+++ b/apps/deluge/docker-compose.json
@@ -1,0 +1,33 @@
+{
+  "services": [
+    {
+      "name": "deluge",
+      "image": "lscr.io/linuxserver/deluge:2.1.1",
+      "isMain": true,
+      "internalPort": 8112,
+      "addPorts": [
+        {
+          "hostPort": 6881,
+          "containerPort": 6881,
+          "udp": true
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "DELUGE_LOGLEVEL": "error"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/deluge/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents",
+          "containerPath": "/media/torrents"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/deluge/docker-compose.json
+++ b/apps/deluge/docker-compose.json
@@ -9,6 +9,7 @@
         {
           "hostPort": 6881,
           "containerPort": 6881,
+          "tcp": true
           "udp": true
         }
       ],


### PR DESCRIPTION
## Dynamic compose for deluge
This is a deluge update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
- [x] Additionnals ports are mapped correctly (6881 TCP & UDP)
##### In app tests :
  - [x] 📝 Login
  - [x] 🌊 Add torrent
  - [x] 🔎 Complete a download and check received data
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/deluge/config:/config
- [x] ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ,DELUGE_LOGLEVEL)