### PR TITLE
fix GUNICORN_NUM_WORKERS from number to tring in grampsweb dynamic compose

### DIFF
--- a/apps/grampsweb/config.json
+++ b/apps/grampsweb/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 5000,
   "id": "grampsweb",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "24.11.0",
   "categories": ["data", "social"],
   "description": "Gramps Web is a web app for collaborative genealogy. It is based on and interoperable with Gramps, the leading open source genealogy desktop application. Gramps Web is free & open source software and puts your privacy and your control of your research data first.",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731929455000
+  "updated_at": 1732010022559
 }

--- a/apps/grampsweb/docker-compose.json
+++ b/apps/grampsweb/docker-compose.json
@@ -7,7 +7,7 @@
       "internalPort": 5000,
       "environment": {
         "GRAMPSWEB_TREE": "${GRAMPSWEB_TREE}",
-        "GUNICORN_NUM_WORKERS": 1
+        "GUNICORN_NUM_WORKERS": "1"
       },
       "volumes": [
         {


### PR DESCRIPTION
Previous error was :
```
Error generating docker-compose.yml file for app grampsweb. Falling back to default docker-compose.yml
{
  "code": "invalid_type",
  "expected": "string",
  "received": "number",
  "path": [
    "environment",
    "GUNICORN_NUM_WORKERS"
  ],
  "message": "Expected string, received number"
}
```
This fix has been tested and correct the issue 👍

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Gramps Web application configuration to version 10.
  
- **Bug Fixes**
	- Adjusted the environment variable type for `GUNICORN_NUM_WORKERS` to ensure proper interpretation in the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->