### PR TITLE
fix(portainer): rollback

### DIFF
--- a/apps/portainer/config.json
+++ b/apps/portainer/config.json
@@ -6,15 +6,16 @@
   "exposable": true,
   "https": true,
   "id": "portainer",
-  "tipi_version": 28,
-  "version": "2.24.0-alpine",
+  "tipi_version": 27,
+  "version": "2.21.4-alpine",
   "categories": ["utilities"],
-  "description": "",
+  "description": "Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments.",
   "short_desc": "Making Docker and Kubernetes management easy.",
-  "author": "portainer.io",
+  "author": "portainer",
   "source": "https://github.com/portainer/portainer",
+  "website": "https://www.portainer.io",
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731485765000
+  "updated_at": 1732032293993
 }

--- a/apps/portainer/docker-compose.yml
+++ b/apps/portainer/docker-compose.yml
@@ -1,15 +1,13 @@
-version: "3.7"
-
 services:
   portainer:
-    image: portainer/portainer-ce:2.24.0-alpine
+    image: portainer/portainer-ce:2.21.4-alpine
     container_name: portainer
     restart: unless-stopped
     ports:
       - ${APP_PORT}:9443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - "${APP_DATA_DIR}/data:/data"
+      - ${APP_DATA_DIR}/data:/data
     networks:
       - tipi_main_network
     labels:
@@ -37,4 +35,5 @@ services:
       traefik.http.routers.portainer-local.entrypoints: websecure
       traefik.http.routers.portainer-local.service: portainer
       traefik.http.routers.portainer-local.tls: true
+      # Runtipi managed
       runtipi.managed: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a detailed description of the Portainer Community Edition as a service delivery platform.
	- Introduced a new label indicating the service is managed by Runtipi.
- **Version Updates**
	- Downgraded the Portainer version from 2.24.0-alpine to 2.21.4-alpine.
	- Updated the tipi_version from 28 to 27.
- **Enhancements**
	- Added a link to the official Portainer website.
	- Updated the author field for branding consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->