### PR TITLE
Add dynamic compose for jackett

### DIFF
--- a/apps/jackett/config.json
+++ b/apps/jackett/config.json
@@ -3,9 +3,10 @@
   "name": "Jackett",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8097,
   "id": "jackett",
-  "tipi_version": 80,
+  "tipi_version": 81,
   "version": "latest",
   "description": "Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches.",
   "short_desc": "API Support for your favorite torrent trackers ",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1732958937332
 }

--- a/apps/jackett/docker-compose.json
+++ b/apps/jackett/docker-compose.json
@@ -1,0 +1,26 @@
+{
+  "services": [
+    {
+      "name": "jackett",
+      "image": "lscr.io/linuxserver/jackett:latest",
+      "isMain": true,
+      "internalPort": 9117,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "AUTO_UPDATE": "true"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents",
+          "containerPath": "/media/torrents"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for jackett
This is a jackett update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🌆 Add indexer and make them avaible for *arr stack
  - [ ] 🌊 Check after a full download (can't test on my side)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ,AUTO_UPDATE)