### PR TITLE
Add dynamic compose for baikal

### DIFF
--- a/apps/baikal/config.json
+++ b/apps/baikal/config.json
@@ -3,9 +3,10 @@
   "name": "Baïkal",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 6556,
   "id": "baikal",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "0.10.1-nginx",
   "categories": ["data", "utilities"],
   "description": "",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731873550000
+  "updated_at": 1733760506693
 }

--- a/apps/baikal/docker-compose.json
+++ b/apps/baikal/docker-compose.json
@@ -1,0 +1,20 @@
+{
+  "services": [
+    {
+      "name": "baikal",
+      "image": "ckulka/baikal:0.10.1-nginx",
+      "isMain": true,
+      "internalPort": 80,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/config",
+          "containerPath": "/var/www/baikal/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/specific",
+          "containerPath": "/var/www/baikal/Specific"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for baikal
This is a baikal update for using dynamic compose. (no other change)
##### Situations tested :
- 💾 Update on existing data
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In App tests :
  - [x] 📝 Register and create entries
  - [x] ⚙ Synchronize CalDav
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/config -> /var/www/baikal/config
- [x] ${APP_DATA_DIR}/specific -> /var/www/baikal/Specific
##### Specific instructions verified :
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for dynamic configuration in the Baïkal application.
	- Added a new Docker Compose configuration for the Baïkal service, facilitating deployment.
  
- **Updates**
	- Incremented the version number of the configuration from 4 to 5.
	- Updated the timestamp for the configuration to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->