### PR TITLE
Add dynamic compose for databag

### DIFF
--- a/apps/databag/config.json
+++ b/apps/databag/config.json
@@ -3,9 +3,10 @@
   "name": "Databag",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8201,
   "id": "databag",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "latest",
   "categories": ["utilities"],
   "description": "Databag is a federated chat app for self-hosting that focuses on user privacy and security; the service includes clients for iOS, Android, and browser.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1733760567442
 }

--- a/apps/databag/docker-compose.json
+++ b/apps/databag/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "databag",
+      "image": "balzack/databag:latest",
+      "isMain": true,
+      "internalPort": 7000,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/databag",
+          "containerPath": "/var/lib/databag"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for databag
This is a databag update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register and create users
  - [x] 📧 connect users and send messsages
  - [x] 🖼 Send attachement in conversations
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/databag:/var/lib/databag