### PR TITLE
Add dynamic compose for esphome

### DIFF
--- a/apps/esphome/config.json
+++ b/apps/esphome/config.json
@@ -4,8 +4,9 @@
   "port": 6052,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "esphome",
-  "tipi_version": 17,
+  "tipi_version": 18,
   "version": "2024.11.3",
   "categories": ["automation"],
   "description": "ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.",
@@ -42,5 +43,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1723905687000,
-  "updated_at": 1733470241000
+  "updated_at": 1733760617261
 }

--- a/apps/esphome/docker-compose.json
+++ b/apps/esphome/docker-compose.json
@@ -1,0 +1,27 @@
+{
+  "services": [
+    {
+      "name": "esphome",
+      "image": "ghcr.io/esphome/esphome:2024.11.3",
+      "isMain": true,
+      "internalPort": 6052,
+      "environment": {
+        "TZ": "${TZ}",
+        "USERNAME": "${ESPHOME_USERNAME:-''}",
+        "PASSWORD": "${ESPHOME_PASSWORD:-''}",
+        "ESPHOME_DASHBOARD_USE_PING": "${ESPHOME_PING:-'false'}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for esphome
This is a esphome update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register and login
  - [x] 🛠 Create a configuration for ESP
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/config:/config
##### Specific instructions verified :
- [x] 🌳 Environment (TZ, USERNAME, PASSWORD, ESPHOME_DASHBOARD_USE_PING)