### PR TITLE
Add dynamic compose for homarr

### DIFF
--- a/apps/homarr/config.json
+++ b/apps/homarr/config.json
@@ -3,9 +3,10 @@
   "name": "Homarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8102,
   "id": "homarr",
-  "tipi_version": 36,
+  "tipi_version": 37,
   "version": "0.15.9",
   "categories": ["utilities"],
   "description": "A homepage for your server.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733695011000
+  "updated_at": 1733760722199
 }

--- a/apps/homarr/docker-compose.json
+++ b/apps/homarr/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "services": [
+    {
+      "name": "homarr",
+      "image": "ghcr.io/ajnart/homarr:0.15.9",
+      "isMain": true,
+      "internalPort": 7575,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/app/data/configs"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/icons",
+          "containerPath": "/app/public/icons"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/dashboard",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for homarr
This is a homarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 🐳 Check container detection
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/app/data/configs
- [x] ${APP_DATA_DIR}/data/icons:/app/public/icons
- [x] ${APP_DATA_DIR}/data/dashboard:/data
- [x] /var/run/docker.sock:/var/run/docker.sock
##### Specific instructions verified :
- [x] 🌳 Environment (TZ)