### PR TITLE
Add dynamic compose for lidarr-deemix

### DIFF
--- a/apps/lidarr-deemix/config.json
+++ b/apps/lidarr-deemix/config.json
@@ -4,8 +4,9 @@
   "port": 8186,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "lidarr-deemix",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "1.5.2",
   "categories": ["media"],
   "description": "Lidarr with some muscles thanks to deemix",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724027516000
+  "updated_at": 1733760840611
 }

--- a/apps/lidarr-deemix/docker-compose.json
+++ b/apps/lidarr-deemix/docker-compose.json
@@ -1,0 +1,42 @@
+{
+  "services": [
+    {
+      "name": "lidarr-deemix",
+      "image": "youegraillot/lidarr-on-steroids:1.5.2",
+      "isMain": true,
+      "internalPort": 8686,
+      "addPorts": [
+        {
+          "hostPort": 8187,
+          "containerPort": 6595
+        }
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config-deemix",
+          "containerPath": "/config_deemix"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/downloads/deemix",
+          "containerPath": "/downloads"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/music",
+          "containerPath": "/music"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/usenet/completed/",
+          "containerPath": "/downloads/completed"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for lidarr-deemix
This is a lidarr-deemix update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
- [x] Additionnals ports are mapped correctly (8187:6595)
##### In app tests :
- [x] 📝 Register
- [x] 💿 Add Deemix client
- [x] 🎵 Downloading metadata
- [x] 🌊 Check after a full download
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/config-deemix:/config_deemix
- [x] ${ROOT_FOLDER_HOST}/media/downloads/deemix:/downloads
- [x] ${ROOT_FOLDER_HOST}/media/data/music:/music
- [x] ${ROOT_FOLDER_HOST}/media/usenet/completed/:/downloads/completed
- [x] ${ROOT_FOLDER_HOST}/media:/media