### PR TITLE
Add dynamic compose for lidarr

### DIFF
--- a/apps/lidarr/config.json
+++ b/apps/lidarr/config.json
@@ -3,9 +3,10 @@
   "name": "Lidarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8131,
   "id": "lidarr",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "2.7.1",
   "categories": ["media", "music"],
   "description": "Lidarr is a music collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new tracks from your favorite artists and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1729926436000
+  "updated_at": 1733760836281
 }

--- a/apps/lidarr/docker-compose.json
+++ b/apps/lidarr/docker-compose.json
@@ -1,0 +1,30 @@
+{
+  "services": [
+    {
+      "name": "lidarr",
+      "image": "ghcr.io/linuxserver/lidarr:2.7.1",
+      "isMain": true,
+      "internalPort": 8686,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for lidarr
This is a lidarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 🛠 Configure Path/Indexer/DL Client
  - [x] 🎵 Downloading metadata
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ)