### PR TITLE
Add dynamic compose for maintainerr

### DIFF
--- a/apps/maintainerr/config.json
+++ b/apps/maintainerr/config.json
@@ -2,9 +2,10 @@
   "name": "Maintainerr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8030,
   "id": "maintainerr",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "2.2.1",
   "categories": ["media", "utilities"],
   "description": "Maintainerr will manage the storage space on your plex server, launching automated actions to delete your files.",
@@ -14,5 +15,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731437302000
+  "updated_at": 1733760868535
 }

--- a/apps/maintainerr/docker-compose.json
+++ b/apps/maintainerr/docker-compose.json
@@ -1,0 +1,19 @@
+{
+  "services": [
+    {
+      "name": "maintainerr",
+      "image": "ghcr.io/jorenn92/maintainerr:2.2.1",
+      "isMain": true,
+      "internalPort": 6246,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/opt/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for maintainerr
This is a maintainerr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 🔧 Connect to Plex
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/opt/data
##### Specific instructions verified :
- [x] 🌳 Environment (TZ)