### PR TITLE
Add dynamic compose for memos

### DIFF
--- a/apps/memos/config.json
+++ b/apps/memos/config.json
@@ -3,9 +3,10 @@
   "name": "Memos",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 5230,
   "id": "memos",
-  "tipi_version": 34,
+  "tipi_version": 35,
   "version": "0.22.5",
   "categories": ["utilities"],
   "description": "Memo hub for knowledge management and collaboration.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1725410453000
+  "updated_at": 1733760902338
 }

--- a/apps/memos/docker-compose.json
+++ b/apps/memos/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "memos",
+      "image": "neosmemo/memos:0.22.5",
+      "isMain": true,
+      "internalPort": 5230,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/memos",
+          "containerPath": "/var/opt/memos"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for memos
This is a memos update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] 📖 Add notes
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/memos:/var/opt/memos
##### Specific instructions verified :
none