### PR TITLE
Dynamic compose/mstream

### DIFF
--- a/apps/mstream/config.json
+++ b/apps/mstream/config.json
@@ -4,8 +4,9 @@
   "port": 8162,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "mstream",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "v5.11.4-ls101",
   "categories": ["music", "media"],
   "description": "mStream is a personal music streaming server. You can use mStream to stream your music from your home computer to any device, anywhere.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1733760955119
 }

--- a/apps/mstream/config.json
+++ b/apps/mstream/config.json
@@ -7,7 +7,7 @@
   "dynamic_config": true,
   "id": "mstream",
   "tipi_version": 3,
-  "version": "v5.11.4-ls101",
+  "version": "v5.12.2-ls190",
   "categories": ["music", "media"],
   "description": "mStream is a personal music streaming server. You can use mStream to stream your music from your home computer to any device, anywhere.",
   "short_desc": "The easiest music streaming server available",

--- a/apps/mstream/docker-compose.json
+++ b/apps/mstream/docker-compose.json
@@ -1,0 +1,25 @@
+{
+  "services": [
+    {
+      "name": "mstream",
+      "image": "lscr.io/linuxserver/mstream:v5.11.4-ls101",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mstream-config",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/music",
+          "containerPath": "/music"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/mstream/docker-compose.json
+++ b/apps/mstream/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "mstream",
-      "image": "lscr.io/linuxserver/mstream:v12.2-ls190",
+      "image": "lscr.io/linuxserver/mstream:v5.12.2-ls190",
       "isMain": true,
       "internalPort": 3000,
       "environment": {

--- a/apps/mstream/docker-compose.json
+++ b/apps/mstream/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "mstream",
-      "image": "lscr.io/linuxserver/mstream:v5.11.4-ls101",
+      "image": "lscr.io/linuxserver/mstream:v12.2-ls190",
       "isMain": true,
       "internalPort": 3000,
       "environment": {

--- a/apps/mstream/docker-compose.yml
+++ b/apps/mstream/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   mstream:
     container_name: mstream
-    image: lscr.io/linuxserver/mstream:v5.11.4-ls101
+    image: lscr.io/linuxserver/mstream:v5.12.2-ls190
     restart: unless-stopped
     ports:
       - ${APP_PORT}:3000


### PR DESCRIPTION
## Dynamic compose for mstream
This is a mstream update for using dynamic compose. + (update to v5.12.2-ls190)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In App tests :
  - [x] 🎵 Scan Music Library and listen
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/mstream-config:/data
- [x] ${ROOT_FOLDER_HOST}/media/data/music:/music
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, GUID, TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the mStream Music application.
	- Added a new Docker Compose configuration for the mStream service.

- **Updates**
	- Updated application version to v5.12.2-ls190.
	- Incremented tipi_version to 3.
	- Updated Docker image version to v5.12.2-ls190.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->