### PR TITLE
Add dynamic compose for obsidian-livesync

### DIFF
--- a/apps/obsidian-livesync/config.json
+++ b/apps/obsidian-livesync/config.json
@@ -4,9 +4,10 @@
   "port": 5984,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "no_gui": true,
   "id": "obsidian-livesync",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "3.1.2",
   "categories": ["utilities"],
   "description": "LiveSync couchdb backend for Obsidian",
@@ -42,5 +43,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1733761005578
 }

--- a/apps/obsidian-livesync/docker-compose.json
+++ b/apps/obsidian-livesync/docker-compose.json
@@ -1,0 +1,24 @@
+{
+  "services": [
+    {
+      "name": "obsidian-livesync",
+      "image": "couchdb:3.1.2",
+      "isMain": true,
+      "internalPort": 5984,
+      "environment": {
+        "COUCHDB_USER": "${OBSIDIAN_LIVESYNC_USER}",
+        "COUCHDB_PASSWORD": "${OBSIDIAN_LIVESYNC_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/couchdb",
+          "containerPath": "/opt/couchdb/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/local.ini",
+          "containerPath": "/opt/couchdb/etc/local.ini"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for obsidian-livesync
This is a obsidian-livesync update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Configure plugin on client
  - [x] ♻ Test data synchronization
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/couchdb:/opt/couchdb/data
- [x] ${APP_DATA_DIR}/data/local.ini:/opt/couchdb/etc/local.ini
##### Specific instructions verified :
- [x] 🌳 Environment (COUCHDB_USER,COUCHDB_PASSWORD)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the Obsidian LiveSync settings.
	- Added a new Docker Compose configuration for the Obsidian LiveSync service, facilitating easier deployment.
  
- **Updates**
	- Incremented the version number for the configuration file.
	- Updated the timestamp to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->