### PR TITLE
Add dynamic compose for paperless-ngx

### DIFF
--- a/apps/paperless-ngx/config.json
+++ b/apps/paperless-ngx/config.json
@@ -3,9 +3,10 @@
   "name": "Paperless-ngx",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8012,
   "id": "paperless-ngx",
-  "tipi_version": 52,
+  "tipi_version": 53,
   "version": "2.13.5",
   "categories": ["utilities"],
   "description": "Paperless-ngx is a community-supported open-source document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.",
@@ -51,5 +52,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731437302000
+  "updated_at": 1733761063811
 }

--- a/apps/paperless-ngx/docker-compose.json
+++ b/apps/paperless-ngx/docker-compose.json
@@ -1,0 +1,82 @@
+{
+  "services": [
+    {
+      "name": "paperless-ngx",
+      "image": "ghcr.io/paperless-ngx/paperless-ngx:2.13.5",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "PAPERLESS_REDIS": "redis://broker:6379",
+        "PAPERLESS_DBHOST": "db",
+        "PAPERLESS_ADMIN_USER": "${PAPERLESS_ADMIN_USERNAME}",
+        "PAPERLESS_ADMIN_PASSWORD": "${PAPERLESS_ADMIN_PASSWORD}",
+        "PAPERLESS_TIKA_ENABLED": "${PAPERLESS_TIKA_ENABLED}",
+        "PAPERLESS_TIKA_GOTENBERG_ENDPOINT": "http://gotenberg:3000",
+        "PAPERLESS_TIKA_ENDPOINT": "http://tika:9998",
+        "PAPERLESS_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "COMPOSE_PROJECT_NAME": "paperless-ngx",
+        "PAPERLESS_CSRF_TRUSTED_ORIGINS": "https://paperless-ngx.${LOCAL_DOMAIN},https://${APP_DOMAIN},http://${INTERNAL_IP}:${APP_PORT}"
+      },
+      "dependsOn": [
+        "db",
+        "broker"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/paperless_data",
+          "containerPath": "/usr/src/paperless/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/paperless_media",
+          "containerPath": "/usr/src/paperless/media"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/paperless_export",
+          "containerPath": "/usr/src/paperless/export"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/paperless_consume",
+          "containerPath": "/usr/src/paperless/consume"
+        }
+      ]
+    },
+    {
+      "name": "broker",
+      "image": "docker.io/library/redis:7",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "db",
+      "image": "docker.io/library/postgres:17",
+      "environment": {
+        "POSTGRES_DB": "paperless",
+        "POSTGRES_USER": "paperless",
+        "POSTGRES_PASSWORD": "paperless"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    },
+    {
+      "name": "gotenberg",
+      "image": "docker.io/gotenberg/gotenberg:8.14",
+      "command": [
+        "gotenberg",
+        "--chromium-disable-javascript=true",
+        "--chromium-allow-list=file:///tmp/.*"
+      ]
+    },
+    {
+      "name": "tika",
+      "image": "ghcr.io/paperless-ngx/tika:latest"
+    }
+  ]
+}

--- a/apps/paperless-ngx/docker-compose.json
+++ b/apps/paperless-ngx/docker-compose.json
@@ -17,10 +17,7 @@
         "COMPOSE_PROJECT_NAME": "paperless-ngx",
         "PAPERLESS_CSRF_TRUSTED_ORIGINS": "https://paperless-ngx.${LOCAL_DOMAIN},https://${APP_DOMAIN},http://${INTERNAL_IP}:${APP_PORT}"
       },
-      "dependsOn": [
-        "db",
-        "broker"
-      ],
+      "dependsOn": ["db", "broker"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/paperless_data",
@@ -68,11 +65,7 @@
     {
       "name": "gotenberg",
       "image": "docker.io/gotenberg/gotenberg:8.14",
-      "command": [
-        "gotenberg",
-        "--chromium-disable-javascript=true",
-        "--chromium-allow-list=file:///tmp/.*"
-      ]
+      "command": ["gotenberg", "--chromium-disable-javascript=true", "--chromium-allow-list=file:///tmp/.*"]
     },
     {
       "name": "tika",


### PR DESCRIPTION
## Dynamic compose for paperless-ngx
This is a paperless-ngx update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
##### In app tests :
  - [x] 📝 Register
  - [x] ⏫ Upload all sort of documents (PDF, DOCX, PNG...)
  - [x] 🍃 Check PDF generation for DOCX,XLSX & PNG (tika & gotenberg)
  - [x] 🕶 Check OCR
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/paperless_data:/usr/src/paperless/data
- [x] ${APP_DATA_DIR}/data/paperless_media:/usr/src/paperless/media
- [x] ${APP_DATA_DIR}/data/paperless_export:/usr/src/paperless/export
- [x] ${APP_DATA_DIR}/data/paperless_consume:/usr/src/paperless/consume
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for Paperless-ngx.
	- Added a new Docker Compose configuration file to orchestrate multiple services for the application.

- **Updates**
	- Incremented version number to reflect recent updates.
	- Updated timestamp for the configuration file to indicate the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->