### PR TITLE
fix(duplicati): add missing env variable

### DIFF
--- a/apps/duplicati/config.json
+++ b/apps/duplicati/config.json
@@ -5,14 +5,21 @@
   "available": true,
   "exposable": true,
   "id": "duplicati",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "2.1.0",
   "categories": ["data"],
   "description": "Duplicati is a free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers.",
   "short_desc": "Store securely encrypted backups in the cloud!",
   "author": "https://github.com/duplicati",
   "source": "https://github.com/linuxserver/docker-duplicati",
-  "form_fields": [],
+  "form_fields": [
+    {
+      "label": "Encryption Key",
+      "type": "random",
+      "min": 32,
+      "env_variable": "DUPLICATI_ENCRYPTION_KEY"
+    }
+  ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
   "updated_at": 1732900997000

--- a/apps/duplicati/docker-compose.yml
+++ b/apps/duplicati/docker-compose.yml
@@ -11,9 +11,10 @@ services:
       - ${ROOT_FOLDER_HOST}:/backups/runtipi-folder
       - /home:/source
     environment:
-      - PUID=1000
-      - PGID=1000
+      - PUID=0
+      - PGID=0
       - TZ=${TZ}
+      - SETTINGS_ENCRYPTION_KEY=${DUPLICATI_ENCRYPTION_KEY}
     networks:
       - tipi_main_network
     labels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new form field for "Encryption Key" in the Duplicati configuration.
	- Added an environment variable for `SETTINGS_ENCRYPTION_KEY` to enhance settings encryption.

- **Updates**
	- Incremented the `tipi_version` from 5 to 6.
	- Updated user and group IDs to use root user (PUID and PGID set to 0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->