### PR TITLE
Add dynamic compose for serge

### DIFF
--- a/apps/serge/config.json
+++ b/apps/serge/config.json
@@ -3,9 +3,10 @@
   "name": "Serge",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8008,
   "id": "serge",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "0.9.0",
   "categories": ["ai"],
   "description": "",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192
+  "updated_at": 1733761222241
 }

--- a/apps/serge/docker-compose.json
+++ b/apps/serge/docker-compose.json
@@ -1,0 +1,20 @@
+{
+  "services": [
+    {
+      "name": "serge",
+      "image": "ghcr.io/serge-chat/serge:0.9.0",
+      "isMain": true,
+      "internalPort": 8008,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/weights",
+          "containerPath": "/usr/src/app/weights"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/data/db/"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for serge
This is a serge update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://localdomain.tld
##### In app tests :
  - [x] 🦙 Download a model
  - [x] 📧 Have a chat with LLM
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/weights:/usr/src/app/weights
- [x] ${APP_DATA_DIR}/data/db:/data/db/
##### Specific instructions verified :
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for the "Serge" application.
	- Added a new Docker Compose configuration for the "serge" service, including service name, image, and volume mappings.

- **Updates**
	- Incremented versioning from 10 to 11 for the "Serge" application configuration.
	- Updated modification timestamp for the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->