### PR TITLE
Add dynamic compose for spacedrive

### DIFF
--- a/apps/spacedrive/config.json
+++ b/apps/spacedrive/config.json
@@ -3,9 +3,10 @@
   "name": "Spacedrive",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 9300,
   "id": "spacedrive",
-  "tipi_version": 6,
+  "tipi_version": 7,
   "version": "0.4.2",
   "categories": ["utilities"],
   "description": "Spacedrive is an open source cross-platform file explorer, powered by a virtual distributed filesystem written in Rust.",
@@ -33,5 +34,5 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724015728000
+  "updated_at": 1733761264561
 }

--- a/apps/spacedrive/docker-compose.json
+++ b/apps/spacedrive/docker-compose.json
@@ -1,0 +1,19 @@
+{
+  "services": [
+    {
+      "name": "spacedrive",
+      "image": "ghcr.io/spacedriveapp/spacedrive/server:0.4.2",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "SD_AUTH": "${SD_AUTH_USER}:${SD_AUTH_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/spacedrive",
+          "containerPath": "/var/spacedrive"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for spacedrive
This is a spacedrive update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:9300
  - [x] https://spacedrive.tipi.lan
##### In app tests :
- [x] 📝 Register
- [x] 🌆 Retrieve data from /var/spacedrive
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/spacedrive:/var/spacedrive
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for Spacedrive.
	- Added a new Docker Compose configuration for the Spacedrive service, including service details and environment variable settings.

- **Updates**
	- Incremented the version number for the configuration.
	- Updated the timestamp for the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->