### PR TITLE
Add dynamic compose for spoolman

### DIFF
--- a/apps/spoolman/config.json
+++ b/apps/spoolman/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 7912,
   "exposable": true,
+  "dynamic_config": true,
   "id": "spoolman",
   "description": "Spoolman is a web service that helps you keep track of your filament spools and how they are being used. It acts as a database, where other printer software such as Octoprint and Moonraker can interact with to have a centralized place for spool information. For example, if used together with Moonraker, your spool weight will automatically be reduced as your print is progressing.",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "0.21.0",
   "categories": ["utilities", "automation"],
   "short_desc": "Keep track of your inventory of 3D-printer filament spools",
@@ -13,5 +14,5 @@
   "source": "https://github.com/Donkie/Spoolman",
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733068838000
+  "updated_at": 1733761273730
 }

--- a/apps/spoolman/docker-compose.json
+++ b/apps/spoolman/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "services": [
+    {
+      "name": "spoolman",
+      "image": "ghcr.io/donkie/spoolman:0.21.0",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "TZ": "${TZ}",
+        "PUID": "0",
+        "PGID": "0"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/home/app/.local/share/spoolman"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for spoolman
This is a spoolman update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:7912
  - [x] https://spoolman.tipi.lan
##### In app tests :
  - [x] 📝 Create entries (filament, etc.)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/home/app/.local/share/spoolman
##### Specific instructions verified :
- [x] 🌳 Environment (TZ, PUID, PGID)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support for the Spoolman application.
	- Added a new Docker Compose configuration for the Spoolman service, facilitating deployment and management.
  
- **Updates**
	- Incremented the version number from 9 to 10 in the configuration file.
	- Updated the timestamp for the configuration file to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->