### PR TITLE
Add dynamic compose for tautulli

### DIFF
--- a/apps/tautulli/config.json
+++ b/apps/tautulli/config.json
@@ -3,9 +3,10 @@
   "name": "Tautulli",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8181,
   "id": "tautulli",
-  "tipi_version": 20,
+  "tipi_version": 21,
   "version": "2.15.0",
   "categories": ["media", "utilities"],
   "description": "Tautulli is a 3rd party application that you can run alongside your Plex Media Server to monitor activity and track various statistics. Most importantly, these statistics include what has been watched, who watched it, when and where they watched it, and how it was watched. The only thing missing is \"why they watched it\", but who am I to question your 42 plays of Frozen. All statistics are presented in a nice and clean interface with many tables and graphs, which makes it easy to brag about your server to everyone else.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1732507253000
+  "updated_at": 1733761315238
 }

--- a/apps/tautulli/docker-compose.json
+++ b/apps/tautulli/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "services": [
+    {
+      "name": "tautulli",
+      "image": "lscr.io/linuxserver/tautulli:2.15.0",
+      "isMain": true,
+      "internalPort": 8181,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for tautulli
This is a tautulli update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8181
  - [x] https://tautulli.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🔧 Connect to Plex Server
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, PGID, TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for Tautulli.
	- Added a new Docker Compose configuration for the Tautulli service.

- **Updates**
	- Incremented version number in configuration.
	- Updated modification timestamp in configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->