### PR TITLE
Dynamic compose/teddit

### DIFF
--- a/apps/teddit/config.json
+++ b/apps/teddit/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "deprecated": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8124,
   "id": "teddit",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "latest",
   "categories": ["social"],
   "description": "A free and open source alternative Reddit front-end focused on privacy. Inspired by the Nitter project.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1733761319987
 }

--- a/apps/teddit/docker-compose.json
+++ b/apps/teddit/docker-compose.json
@@ -1,0 +1,54 @@
+{
+  "services": [
+    {
+      "name": "teddit",
+      "image": "teddit/teddit:latest",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "REDIS_HOST": "teddit-redis",
+        "DOMAIN": "${APP_DOMAIN}",
+        "THEME": "dark",
+        "HTTPS_ENABLED": "false",
+        "REDIRECT_HTTP_TO_HTTPS": "false",
+        "REDIRECT_WWW": "false"
+      },
+      "dependsOn": [
+        "teddit-redis"
+      ],
+      "healthCheck": {
+        "test": [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/about"
+        ],
+        "interval": "1m",
+        "timeout": "3s",
+        "retries": 3
+      }
+    },
+    {
+      "name": "teddit-redis",
+      "image": "redis:alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "healthCheck": {
+        "test": [
+          "CMD",
+          "redis-cli",
+          "ping"
+        ],
+        "interval": "1s",
+        "timeout": "3s",
+        "retries": 30
+      }
+    }
+  ]
+}

--- a/apps/teddit/docker-compose.json
+++ b/apps/teddit/docker-compose.json
@@ -13,18 +13,9 @@
         "REDIRECT_HTTP_TO_HTTPS": "false",
         "REDIRECT_WWW": "false"
       },
-      "dependsOn": [
-        "teddit-redis"
-      ],
+      "dependsOn": ["teddit-redis"],
       "healthCheck": {
-        "test": [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:8080/about"
-        ],
+        "test": ["wget --no-verbose --tries=1 --spider http://localhost:8080/about"],
         "interval": "1m",
         "timeout": "3s",
         "retries": 3
@@ -40,11 +31,7 @@
         }
       ],
       "healthCheck": {
-        "test": [
-          "CMD",
-          "redis-cli",
-          "ping"
-        ],
+        "test": ["redis-cli ping"],
         "interval": "1s",
         "timeout": "3s",
         "retries": 30

--- a/apps/teddit/docker-compose.json
+++ b/apps/teddit/docker-compose.json
@@ -15,7 +15,7 @@
       },
       "dependsOn": ["teddit-redis"],
       "healthCheck": {
-        "test": ["wget --no-verbose --tries=1 --spider http://localhost:8080/about"],
+        "test": "wget --no-verbose --tries=1 --spider http://localhost:8080/about",
         "interval": "1m",
         "timeout": "3s",
         "retries": 3
@@ -31,7 +31,7 @@
         }
       ],
       "healthCheck": {
-        "test": ["redis-cli ping"],
+        "test": "redis-cli ping",
         "interval": "1s",
         "timeout": "3s",
         "retries": 30


### PR DESCRIPTION
## Dynamic compose for teddit
This is a teddit update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8124
  - [x] https://teddit.tipi.lan
##### In app tests :
- [x] 🤓 Check r/runtipi
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x]${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for the "teddit" application.
	- Added a new Docker Compose configuration for running the "teddit" application with Redis support.
  
- **Updates**
	- Updated the version of the underlying framework for the application. 
	- Modified the last updated timestamp for the configuration. 

- **Service Configuration**
	- Defined services for "teddit" and "teddit-redis" with health checks to ensure operational status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->