### PR TITLE
Add dynamic compose for trilium

### DIFF
--- a/apps/trilium/config.json
+++ b/apps/trilium/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8267,
   "exposable": true,
+  "dynamic_config": true,
   "id": "trilium",
   "description": "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases. ",
-  "tipi_version": 17,
+  "tipi_version": 18,
   "version": "0.63.7",
   "categories": ["utilities"],
   "short_desc": "An open-source, self-hosted Notion alterative",
@@ -13,5 +14,5 @@
   "source": "https://github.com/zadam/trilium",
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1733761344660
 }

--- a/apps/trilium/docker-compose.json
+++ b/apps/trilium/docker-compose.json
@@ -1,0 +1,19 @@
+{
+  "services": [
+    {
+      "name": "trilium",
+      "image": "ghcr.io/zadam/trilium:0.63.7",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "TRILIUM_DATA_DIR": "/home/node/trilium-data"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/home/node/trilium-data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for trilium
This is a trilium update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8267
  - [x] https://trilium.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 📝 Take some notes
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/home/node/trilium-data
##### Specific instructions verified :
none