### PR TITLE
Add dynamic compose for wizarr

### DIFF
--- a/apps/wizarr/config.json
+++ b/apps/wizarr/config.json
@@ -4,8 +4,9 @@
   "port": 5690,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "wizarr",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "4.1.1",
   "categories": ["utilities"],
   "description": "Wizarr is an automatic user invitation system for Plex and Jellyfin. Create a unique link and share it to a user and they will be invited to your Media Server after they complete there signup proccess! They can even be guided to download the clients and read instructions on how to use your media software!",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1733761417403
 }

--- a/apps/wizarr/docker-compose.json
+++ b/apps/wizarr/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "wizarr",
+      "image": "ghcr.io/wizarrrr/wizarr:4.1.1",
+      "isMain": true,
+      "internalPort": 5690,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/database",
+          "containerPath": "/data/database"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for wizarr
This is a wizarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:5690
  - [x] https://wizarr.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] ⚙ Connect to Plex Server
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/database:/data/database