### PR TITLE
Add dynamic compose for grafana

### DIFF
--- a/apps/grafana/config.json
+++ b/apps/grafana/config.json
@@ -4,8 +4,9 @@
   "port": 8160,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "grafana",
-  "tipi_version": 40,
+  "tipi_version": 41,
   "version": "11.4.0",
   "categories": ["data"],
   "description": "The open and composable observability and data visualization platform",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733433081000
+  "updated_at": 1734113851889
 }

--- a/apps/grafana/docker-compose.json
+++ b/apps/grafana/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "grafana",
+      "image": "grafana/grafana-oss:11.4.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/grafana",
+          "containerPath": "/var/lib/grafana"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for grafana
This is a grafana update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
- [x] http://localip:8160
- [x] https://grafana.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 📊 Check metrics
	- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/grafana:/var/lib/grafana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration for Grafana.
	- Introduced a new Docker Compose configuration for the Grafana service, including data persistence and port exposure.

- **Updates**
	- Incremented version number for Grafana configuration from 40 to 41.
	- Updated timestamp for the configuration file to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->