### PR TITLE
Add dynamic compose for mdns-repeater

### DIFF
--- a/apps/mdns-repeater/config.json
+++ b/apps/mdns-repeater/config.json
@@ -3,10 +3,11 @@
   "name": "MDNS Repeater",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 9998,
   "id": "mdns-repeater",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "latest",
   "categories": ["utilities", "automation"],
   "author": "angelnu",
@@ -31,5 +32,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1734113996789
 }

--- a/apps/mdns-repeater/docker-compose.json
+++ b/apps/mdns-repeater/docker-compose.json
@@ -1,0 +1,14 @@
+{
+  "services": [
+    {
+      "name": "mdns-repeater",
+      "image": "angelnu/mdns_repeater:latest",
+      "isMain": true,
+      "networkMode": "host",
+      "environment": {
+        "hostNIC": "${MDNS_HOST_NIC}",
+        "dockerNIC": "${MDNS_DOCKER_NIC}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for mdns-repeater
This is a mdns-repeater update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### In app tests :
- [x] 📝 Check if it works (nothing special)
##### Volumes mapping verified :
none
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🌐 Network Mode (host)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Docker Compose configuration for the `mdns-repeater` service.
	- Added a dynamic configuration option in the MDNS Repeater settings.

- **Updates**
	- Updated the application version from 2 to 3 in the configuration.
	- Revised the timestamp for the last update in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->