### PR TITLE
Add dynamic compose for pinchflat

### DIFF
--- a/apps/pinchflat/config.json
+++ b/apps/pinchflat/config.json
@@ -4,8 +4,9 @@
   "port": 8945,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "pinchflat",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "2024.12.10",
   "categories": ["media"],
   "description": "Your next YouTube media manager",
@@ -34,5 +35,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733879136000
+  "updated_at": 1734114135009
 }

--- a/apps/pinchflat/docker-compose.json
+++ b/apps/pinchflat/docker-compose.json
@@ -1,0 +1,29 @@
+{
+  "services": [
+    {
+      "name": "pinchflat",
+      "image": "keglin/pinchflat:v2024.12.10",
+      "isMain": true,
+      "internalPort": 8945,
+      "environment": {
+        "BASIC_AUTH_USERNAME": "${PINCHFLAT_BASIC_AUTH_USERNAME}",
+        "BASIC_AUTH_PASSWORD": "${PINCHFLAT_BASIC_AUTH_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/downloads",
+          "containerPath": "/downloads"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for pinchflat
This is a pinchflat update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
	- [x] http://localip:8945
	- [x] https://pinchflat.tipi.lan
##### In app tests :
  - [x] 👀 Add a Youtube playlist to watch
  - [x] 🎞 Check fully downloaded videos
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/downloads:/downloads
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the Pinchflat application.
	- Added a new Docker Compose configuration for the Pinchflat service, including environment variables and volume mappings.
  
- **Updates**
	- Incremented the application version from 16 to 17.
	- Updated the modification timestamp for the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->