### PR TITLE
Add dynamic compose for wallos

### DIFF
--- a/apps/wallos/config.json
+++ b/apps/wallos/config.json
@@ -4,8 +4,9 @@
   "port": 8222,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "wallos",
-  "tipi_version": 93,
+  "tipi_version": 94,
   "version": "2.41.0",
   "categories": ["finance"],
   "description": "Open-Source Personal Subscription Tracker",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733976925000
+  "updated_at": 1734114361053
 }

--- a/apps/wallos/docker-compose.json
+++ b/apps/wallos/docker-compose.json
@@ -1,0 +1,28 @@
+{
+  "services": [
+    {
+      "name": "wallos",
+      "image": "bellamy/wallos:2.41.0",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/www/html/db"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/logos",
+          "containerPath": "/var/www/html/images/uploads/logos"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for wallos
This is a wallos update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
	- [x] http://localip:8222
	- [x] https://wallos.tipi.local
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 💲 Add some subscriptions with a logo
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/db:/var/www/html/db
- [x] ${APP_DATA_DIR}/data/logos:/var/www/html/images/uploads/logos
##### Specific instructions verified :
- [x] 🌳 Environment (TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new service configuration for the Wallos application.
	- Added dynamic configuration capability.
- **Updates**
	- Incremented version number for the application.
	- Updated timestamp to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->