### PR TITLE
Add dynamic compose for whoogle

### DIFF
--- a/apps/whoogle/config.json
+++ b/apps/whoogle/config.json
@@ -3,9 +3,10 @@
   "name": "Whoogle Search",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8255,
   "id": "whoogle",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "0.9.1",
   "categories": ["social"],
   "description": "Get Google search results, but without any ads, JavaScript, AMP links, cookies, or IP address tracking.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730916653000
+  "updated_at": 1734114376972
 }

--- a/apps/whoogle/docker-compose.json
+++ b/apps/whoogle/docker-compose.json
@@ -1,0 +1,13 @@
+{
+  "services": [
+    {
+      "name": "whoogle",
+      "image": "benbusby/whoogle-search:0.9.1",
+      "isMain": true,
+      "internalPort": 8255,
+      "environment": {
+        "EXPOSE_PORT": 8255
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for whoogle
This is a whoogle update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
- [x] http://localip:8255
- [x] https://whoogle.tipi.lan
##### In app tests :
- [x] 🔎 Try a basic search
##### Volumes mapping verified :
none
##### Specific instructions verified :
- [x] 🌳 Environment (EXPOSE_PORT)