### PR TITLE
Add dynamic compose for hammond (+ timezone adjustment)

### DIFF
--- a/apps/hammond/config.json
+++ b/apps/hammond/config.json
@@ -13,14 +13,7 @@
   "short_desc": "Self hosted vehicle and expense management system. Like Clarkson, but better",
   "author": "Akhilrex, alfhou",
   "source": "https://github.com/alfhou/hammond",
-  "form_fields": [
-    {
-      "type": "text",
-      "label": "TimeZone",
-      "placeholder": "Europe/Paris",
-      "env_variable": "HAMMOND_TZ"
-    }
-  ],
+  "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
   "updated_at": 1734113869814

--- a/apps/hammond/config.json
+++ b/apps/hammond/config.json
@@ -4,8 +4,9 @@
   "port": 8185,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "hammond",
-  "tipi_version": 6,
+  "tipi_version": 7,
   "version": "0.0.24",
   "categories": ["utilities"],
   "description": "Self hosted vehicle and expense management system. Like Clarkson, but better",
@@ -22,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1734113869814
 }

--- a/apps/hammond/docker-compose.json
+++ b/apps/hammond/docker-compose.json
@@ -1,0 +1,38 @@
+{
+  "services": [
+    {
+      "name": "hammond",
+      "image": "alfhou/hammond:v0.0.24",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "TZ": "${HAMMOND_TZ-Europe/Paris}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/assets",
+          "containerPath": "/assets"
+        },
+        {
+          "hostPath": "/etc/timezone",
+          "containerPath": "/etc/timezone"
+        },
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "wget --no-verbose --tries=1 --spider http://localhost:3000"
+      }
+    }
+  ]
+}

--- a/apps/hammond/docker-compose.json
+++ b/apps/hammond/docker-compose.json
@@ -6,7 +6,7 @@
       "isMain": true,
       "internalPort": 3000,
       "environment": {
-        "TZ": "${HAMMOND_TZ-Europe/Paris}"
+        "TZ": "${TZ}"
       },
       "volumes": [
         {
@@ -19,11 +19,13 @@
         },
         {
           "hostPath": "/etc/timezone",
-          "containerPath": "/etc/timezone"
+          "containerPath": "/etc/timezone",
+          "readOnly": true
         },
         {
           "hostPath": "/etc/localtime",
-          "containerPath": "/etc/localtime"
+          "containerPath": "/etc/localtime",
+          "readOnly": true
         }
       ],
       "healthCheck": {

--- a/apps/hammond/docker-compose.yml
+++ b/apps/hammond/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${APP_DATA_DIR}/data/assets:/assets
-      - /etc/timezone:/etc/timezone
-      - /etc/localtime:/etc/localtime
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     environment:
-      - TZ=${HAMMOND_TZ-Europe/Paris}
+      - TZ=${TZ}
     restart: unless-stopped
     networks:
       - tipi_main_network


### PR DESCRIPTION
## Dynamic compose for hammond
This is a hammond update for using dynamic compose. (and little adjustements for timezone)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8185
  - [x] https://hammond.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries (car and bills)
  - [x] 🖼 Uploading image
  - [x] ⏲ Check correct timezone
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/assets:/assets
- [x] /etc/timezone:/etc/timezone (add readonly)
- [x] /etc/localtime:/etc/localtime (add readonly)
##### Specific instructions verified :
- [x] 🌳 Environment (changed to used TZ)
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the Hammond application.
	- Added a new Docker Compose configuration for the Hammond service.

- **Updates**
	- Updated the version of the application configuration.
	- Cleared existing form fields in the configuration.
	- Enhanced security by making timezone volume mounts read-only.
	- Improved flexibility in timezone configuration by updating the environment variable.

- **Bug Fixes**
	- Adjusted health check settings for the Hammond service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->