### PR TITLE
Add dynamic compose for kanboard

### DIFF
--- a/apps/kanboard/config.json
+++ b/apps/kanboard/config.json
@@ -2,10 +2,11 @@
   "name": "Kanboard",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8010,
   "id": "kanboard",
   "description": "Kanboard is a free and open source Kanban project management software.",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "1.2.42",
   "categories": ["development"],
   "short_desc": "Open Source Kanban Board",
@@ -22,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731437600000
+  "updated_at": 1734113923199
 }

--- a/apps/kanboard/docker-compose.json
+++ b/apps/kanboard/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "services": [
+    {
+      "name": "kanboard",
+      "image": "kanboard/kanboard:v1.2.42",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "PLUGIN_INSTALLER": "${PLUGIN_INSTALLER}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/kanboard_data",
+          "containerPath": "/var/www/app/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/kanboard_plugins",
+          "containerPath": "/var/www/app/plugins"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for kanboard
This is a kanboard update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8010
  - [x] https://kanboard.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🌆 Create a project, add tasks and pictures
  - [x] 🗃 Install a plugin
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/kanboard_data:/var/www/app/data
- [x] ${APP_DATA_DIR}/data/kanboard_plugins:/var/www/app/plugins
##### Specific instructions verified :
- [x] 🌳 Environment (PLUGIN_INSTALLER)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for dynamic configuration in Kanboard.
	- Added a new Docker Compose configuration for the Kanboard application, including a service for Kanboard.
  
- **Updates**
	- Updated the versioning system for Kanboard from version 16 to 17.
	- Revised the configuration's update timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->