### PR TITLE
Add dynamic compose for koillection

### DIFF
--- a/apps/koillection/config.json
+++ b/apps/koillection/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "port": 8050,
   "exposable": true,
+  "dynamic_config": true,
   "id": "koillection",
   "description": "Koillection is a self-hosted service allowing users to manage any kind of collections.",
-  "tipi_version": 18,
+  "tipi_version": 19,
   "version": "1.5.16",
   "categories": ["utilities"],
   "short_desc": "Koillection allow you to manage any kind of collections.",
@@ -31,5 +32,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1732921300000
+  "updated_at": 1734113945434
 }

--- a/apps/koillection/docker-compose.json
+++ b/apps/koillection/docker-compose.json
@@ -23,9 +23,7 @@
         "DB_PASSWORD": "{KOILLECTION_DB_PASSWORD}",
         "DB_VERSION": "15"
       },
-      "dependsOn": [
-        "koillection-db"
-      ],
+      "dependsOn": ["koillection-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/uploads",

--- a/apps/koillection/docker-compose.json
+++ b/apps/koillection/docker-compose.json
@@ -1,0 +1,52 @@
+{
+  "services": [
+    {
+      "name": "koillection",
+      "image": "koillection/koillection:1.5.16",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "APP_DEBUG": "0",
+        "APP_ENV": "prod",
+        "HTTPS_ENABLED": "{APP_EXPOSED}",
+        "UPLOAD_MAX_FILESIZE": "20M",
+        "PHP_MEMORY_LIMIT": "512M",
+        "PHP_TZ": "${TZ}",
+        "CORS_ALLOW_ORIGIN": "*",
+        "JWT_SECRET_KEY": "%kernel.project_dir%/config/jwt/private.pem",
+        "JWT_PUBLIC_KEY": "%kernel.project_dir%/config/jwt/public.pem",
+        "DB_DRIVER": "pdo_pgsql",
+        "DB_NAME": "koillection",
+        "DB_HOST": "koillection-db",
+        "DB_PORT": "5432",
+        "DB_USER": "{KOILLECTION_DB_USER}",
+        "DB_PASSWORD": "{KOILLECTION_DB_PASSWORD}",
+        "DB_VERSION": "15"
+      },
+      "dependsOn": [
+        "koillection-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uploads",
+          "containerPath": "/uploads"
+        }
+      ]
+    },
+    {
+      "name": "koillection-db",
+      "image": "postgres:15",
+      "environment": {
+        "POSTGRES_DB": "koillection",
+        "POSTGRES_USER": "{KOILLECTION_DB_USER}",
+        "POSTGRES_PASSWORD": "{KOILLECTION_DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/volumes/postgresql",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for koillection
This is a koillection update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8050
  - [x] https://koillection.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 📝 Create photo collection
  - [x] 🖼 Uploading data
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/uploads:/uploads
- [x] ${APP_DATA_DIR}/data/volumes/postgresql:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for the Koillection application.
	- Added a new Docker Compose configuration for deploying the Koillection application alongside a PostgreSQL database.

- **Updates**
	- Incremented version number for the Koillection application configuration. 
	- Updated modification timestamp for the configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->