### PR TITLE
Add dynamic compose for linkwarden

### DIFF
--- a/apps/linkwarden/config.json
+++ b/apps/linkwarden/config.json
@@ -4,8 +4,9 @@
   "port": 8199,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "linkwarden",
-  "tipi_version": 27,
+  "tipi_version": 28,
   "version": "2.8.4",
   "categories": ["data"],
   "description": "A self-hosted, open-source collaborative bookmark manager to collect, organize and archive webpages.",
@@ -36,5 +37,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733016079000
+  "updated_at": 1734113973098
 }

--- a/apps/linkwarden/docker-compose.json
+++ b/apps/linkwarden/docker-compose.json
@@ -11,9 +11,7 @@
         "NEXTAUTH_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/api/v1/auth",
         "NEXT_PUBLIC_DISABLE_REGISTRATION": "${LINKWARDEN_NEXT_PUBLIC_DISABLE_REGISTRATION}"
       },
-      "dependsOn": [
-        "linkwarden-db"
-      ],
+      "dependsOn": ["linkwarden-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/linkwarden",

--- a/apps/linkwarden/docker-compose.json
+++ b/apps/linkwarden/docker-compose.json
@@ -1,0 +1,40 @@
+{
+  "services": [
+    {
+      "name": "linkwarden",
+      "image": "ghcr.io/linkwarden/linkwarden:v2.8.4",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "DATABASE_URL": "postgresql://tipi:${LINKWARDEN_DB_PASSWORD}@linkwarden-db:5432/linkwarden",
+        "NEXTAUTH_SECRET": "${LINKWARDEN_NEXTAUTH_SECRET}",
+        "NEXTAUTH_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/api/v1/auth",
+        "NEXT_PUBLIC_DISABLE_REGISTRATION": "${LINKWARDEN_NEXT_PUBLIC_DISABLE_REGISTRATION}"
+      },
+      "dependsOn": [
+        "linkwarden-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/linkwarden",
+          "containerPath": "/data/data"
+        }
+      ]
+    },
+    {
+      "name": "linkwarden-db",
+      "image": "postgres:16-alpine",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${LINKWARDEN_DB_PASSWORD}",
+        "POSTGRES_DB": "linkwarden"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for linkwarden
This is a linkwarden update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8199
  - [ ] https://linkwarden.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🔗 Add Link
  - [x] 🌆 Check archive created
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/linkwarden:/data/data
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment