### PR TITLE
Add dynamic compose for tasks-md

### DIFF
--- a/apps/tasks-md/config.json
+++ b/apps/tasks-md/config.json
@@ -4,8 +4,9 @@
   "port": 8157,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "tasks-md",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "2.5.4",
   "categories": ["development"],
   "description": "A self-hosted, file based task management board that supports Markdown syntax",
@@ -23,5 +24,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733113301000
+  "updated_at": 1734114311635
 }

--- a/apps/tasks-md/docker-compose.json
+++ b/apps/tasks-md/docker-compose.json
@@ -1,0 +1,27 @@
+{
+  "services": [
+    {
+      "name": "tasks-md",
+      "image": "baldissaramatheus/tasks.md:2.5.4",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "TITLE": "\"${TASKS_MD_TITLE}\""
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/files",
+          "containerPath": "/tasks/"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config/"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/stylesheets",
+          "containerPath": "/usr/share/nginx/html/stylesheets/"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/tasks-md/docker-compose.json
+++ b/apps/tasks-md/docker-compose.json
@@ -6,7 +6,7 @@
       "isMain": true,
       "internalPort": 8080,
       "environment": {
-        "TITLE": "${TASKS_MD_TITLE}""
+        "TITLE": "${TASKS_MD_TITLE}"
       },
       "volumes": [
         {

--- a/apps/tasks-md/docker-compose.json
+++ b/apps/tasks-md/docker-compose.json
@@ -6,7 +6,7 @@
       "isMain": true,
       "internalPort": 8080,
       "environment": {
-        "TITLE": "\"${TASKS_MD_TITLE}\""
+        "TITLE": "${TASKS_MD_TITLE}""
       },
       "volumes": [
         {


### PR DESCRIPTION
## Dynamic compose for tasks-md
This is a tasks-md update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8157
  - [x] https://tasks-md.tipi.lan
##### In app tests :
  - [x] 📝 create notes
  - [x] 🌆 Add photo
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/files:/tasks/
- [x] ${APP_DATA_DIR}/data/config:/config/
- [x] ${APP_DATA_DIR}/data/stylesheets:/usr/share/nginx/html/stylesheets/
##### Specific instructions verified :
- [x] 🌳 Environment (TITLE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capability for the "Tasks.md" application.
	- Added a new Docker Compose configuration for the `tasks-md` service, enabling persistent data storage and configuration management.

- **Updates**
	- Updated the version of the application from 11 to 12.
	- Modified the timestamp to reflect the latest update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->