### PR TITLE
Add dynamic compose for emby

### DIFF
--- a/apps/emby/config.json
+++ b/apps/emby/config.json
@@ -3,9 +3,10 @@
   "name": "Emby",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8325,
   "id": "emby",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "4.8.10",
   "categories": ["media"],
   "description": "Emby is a media server designed to organize, play, and stream audio and video to a variety of devices",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1727806832000
+  "updated_at": 1734113784756
 }

--- a/apps/emby/docker-compose.json
+++ b/apps/emby/docker-compose.json
@@ -1,0 +1,25 @@
+{
+  "services": [
+    {
+      "name": "emby",
+      "image": "lscr.io/linuxserver/emby:4.8.10",
+      "isMain": true,
+      "internalPort": 8096,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data",
+          "containerPath": "/media/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for emby
This is a emby update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8325
  - [x] https://emby.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🍿 Play some local media
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${ROOT_FOLDER_HOST}/media/data:/media/data
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, PGID, TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in the Emby application.
	- Introduced a new Docker Compose configuration for the Emby media server.

- **Updates**
	- Incremented the version of the configuration from 3 to 4.
	- Updated the modification timestamp in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->