### PR TITLE
Add dynamic compose for fireshare

### DIFF
--- a/apps/fireshare/config.json
+++ b/apps/fireshare/config.json
@@ -4,8 +4,9 @@
   "port": 8140,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "fireshare",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "1.2.20",
   "categories": ["development"],
   "description": "Self host your media and share with unique links. Share your game clips, videos, or other media via unique links.",
@@ -38,5 +39,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1734113805119
 }

--- a/apps/fireshare/docker-compose.json
+++ b/apps/fireshare/docker-compose.json
@@ -1,0 +1,32 @@
+{
+  "services": [
+    {
+      "name": "fireshare",
+      "image": "shaneisrael/fireshare:v1.2.20",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "ADMIN_USERNAME": "${FIRESHARE_USERNAME}",
+        "ADMIN_PASSWORD": "${FIRESHARE_PASSWORD}",
+        "SECRET_KEY": "${FIRESHARE_SECRET_KEY}",
+        "MINUTES_BETWEEN_VIDEO_SCANS": "5",
+        "PUID": "1000",
+        "PGID": "1000"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/fireshare_data",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/fireshare_processed",
+          "containerPath": "/processed"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/videos/fireshare_videos",
+          "containerPath": "/videos"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for fireshare
This is a fireshare update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8140
  - [x] https://fireshare.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🎞 Upload videos
  - [x] 🎆 Share some files
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/fireshare_data:/data
- [x] ${APP_DATA_DIR}/data/fireshare_processed:/processed
- [x] ${ROOT_FOLDER_HOST}/media/data/videos/fireshare_videos:/videos
##### Specific instructions verified :
- [x] 🌳 Environment (ADMIN_USERNAME, ADMIN_PASSWORD, SECRET_KEY, MINUTES_BETWEEN_VIDEO_SCANS, PUID, PGID)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for dynamic configuration in the Fireshare application.
	- Added a new Docker Compose configuration for the Fireshare service, enhancing service management and data persistence.

- **Updates**
	- Incremented application version from 13 to 14.
	- Updated configuration timestamp to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->