### PR TITLE
Add dynamic compose for flatnotes

### DIFF
--- a/apps/flatnotes/config.json
+++ b/apps/flatnotes/config.json
@@ -3,9 +3,10 @@
   "name": "flatnotes",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "flatnotes",
   "port": 8137,
-  "tipi_version": 31,
+  "tipi_version": 32,
   "version": "5.3.2",
   "categories": ["utilities"],
   "description": "A self-hosted, database-less note taking web app that utilises a flat folder of markdown files for storage.",
@@ -51,5 +52,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733856109000
+  "updated_at": 1734113808714
 }

--- a/apps/flatnotes/docker-compose.json
+++ b/apps/flatnotes/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "services": [
+    {
+      "name": "flatnotes",
+      "image": "dullage/flatnotes:v5.3.2",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "FLATNOTES_AUTH_TYPE": "${FLATNOTES_AUTH_TYPE}",
+        "FLATNOTES_USERNAME": "${FLATNOTES_USERNAME}",
+        "FLATNOTES_PASSWORD": "${FLATNOTES_PASSWORD}",
+        "FLATNOTES_SECRET_KEY": "${FLATNOTES_SECRET_KEY}",
+        "FLATNOTES_TOTP_KEY": "${FLATNOTES_TOTP_KEY}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for flatnotes
This is a flatnotes update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8137
  - [x] https://flatnotes.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] ✍️ Write docs
  - [x] 🖼 Uploading photos
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic configuration option for the `flatnotes` application.
	- Added a new Docker Compose configuration for the `flatnotes` service, including environment variables and data persistence settings.
  
- **Updates**
	- Incremented the version number for the underlying system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->