### PR TITLE
Add dynamic compose for flightlog

### DIFF
--- a/apps/flightlog/config.json
+++ b/apps/flightlog/config.json
@@ -3,9 +3,10 @@
   "name": "Flightlog",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8934,
   "id": "flightlog",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "2.1.1",
   "categories": ["utilities", "data"],
   "description": "Easily keep track of your flight history",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1725836550000
+  "updated_at": 1734113812356
 }

--- a/apps/flightlog/docker-compose.json
+++ b/apps/flightlog/docker-compose.json
@@ -1,0 +1,19 @@
+{
+  "services": [
+    {
+      "name": "flightlog",
+      "image": "perdian/flightlog:v2.1.1",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "FLIGHTLOG_SERVER_CONTEXT_PATH": "/"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/flightlog/database"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for flightlog
This is a flightlog update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:
  - [x] https://flightlog.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🛩 Track flights
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/db:/var/flightlog/database
##### Specific instructions verified :
- [x] 🌳 Environment (FLIGHTLOG_SERVER_CONTEXT_PATH=/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic configuration option for the Flightlog application.
	- Added a new Docker Compose configuration for the Flightlog service, enhancing deployment capabilities.

- **Updates**
	- Updated the version of the configuration from 3 to 4.
	- Modified the timestamp for the last configuration update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->