### PR TITLE
Add dynamic compose for gotify

### DIFF
--- a/apps/gotify/config.json
+++ b/apps/gotify/config.json
@@ -5,7 +5,8 @@
   "port": 8129,
   "id": "gotify",
   "exposable": true,
-  "tipi_version": 8,
+  "dynamic_config": true,
+  "tipi_version": 9,
   "version": "2.6.1",
   "categories": ["utilities"],
   "description": "Simple server for sending and receiving notification messages.",
@@ -33,5 +34,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731777033000
+  "updated_at": 1734113844819
 }

--- a/apps/gotify/docker-compose.json
+++ b/apps/gotify/docker-compose.json
@@ -1,0 +1,20 @@
+{
+  "services": [
+    {
+      "name": "gotify",
+      "image": "gotify/server:2.6.1",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "GOTIFY_DEFAULTUSER_NAME": "${GOTIFY_DEFAULTUSER_NAME}",
+        "GOTIFY_DEFAULTUSER_PASS": "${GOTIFY_DEFAULTUSER_PASS}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/app/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for gotify
This is a gotify update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8129
  - [x] https://gotify.tipi.lan
##### In app tests :
  - [x] 📝 Create entries
  - [x] 💻 Activate on PC
  - [x] 🔔 Send notifications
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/app/data
##### Specific instructions verified :
- [x] 🌳 Environment