### PR TITLE
Add dynamic compose for grav

### DIFF
--- a/apps/grav/config.json
+++ b/apps/grav/config.json
@@ -4,8 +4,9 @@
   "port": 8161,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "grav",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "1.7.48",
   "categories": ["social", "media"],
   "description": "Grav is a Fast, Simple, and Flexible, file-based Web-platform. There is Zero installation required. It follows similar principles to other flat-file CMS platforms, but has a different design philosophy than most. Grav comes with a powerful Package Management System to allow for simple installation and upgrading of plugins and themes, as well as simple updating of Grav itself.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730917272000
+  "updated_at": 1734113855467
 }

--- a/apps/grav/docker-compose.json
+++ b/apps/grav/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "services": [
+    {
+      "name": "grav",
+      "image": "lscr.io/linuxserver/grav:1.7.48",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/grav-comfig",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for grav
This is a grav update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8161
  - [x] https://grav.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🕸 Edit web pages
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/grav-comfig:/config
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, GUID, TZ)