### PR TITLE
Dynamic compose/kapowarr

### DIFF
--- a/apps/kapowarr/config.json
+++ b/apps/kapowarr/config.json
@@ -3,9 +3,10 @@
   "name": "Kapowarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8194,
   "id": "kapowarr",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "v1.0.0-beta-3",
   "categories": ["media", "utilities"],
   "description": "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1734113927299
 }

--- a/apps/kapowarr/config.json
+++ b/apps/kapowarr/config.json
@@ -7,7 +7,7 @@
   "port": 8194,
   "id": "kapowarr",
   "tipi_version": 4,
-  "version": "v1.0.0-beta-3",
+  "version": "v1.0.0",
   "categories": ["media", "utilities"],
   "description": "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.",
   "short_desc": "Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.",

--- a/apps/kapowarr/docker-compose.json
+++ b/apps/kapowarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "kapowarr",
-      "image": "mrcas/kapowarr:v1.0.0-beta-3",
+      "image": "mrcas/kapowarr:v1.0.0",
       "isMain": true,
       "internalPort": 5656,
       "volumes": [

--- a/apps/kapowarr/docker-compose.json
+++ b/apps/kapowarr/docker-compose.json
@@ -1,0 +1,29 @@
+{
+  "services": [
+    {
+      "name": "kapowarr",
+      "image": "mrcas/kapowarr:v1.0.0-beta-3",
+      "isMain": true,
+      "internalPort": 5656,
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/kapowarr-db",
+          "containerPath": "/app/db"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/downloads/kapowarr",
+          "containerPath": "/app/temp_downloads"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/kapowarr/docker-compose.yml
+++ b/apps/kapowarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   kapowarr:
-    image: mrcas/kapowarr:v1.0.0-beta-3
+    image: mrcas/kapowarr:v1.0.0
     container_name: kapowarr
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Dynamic compose for kapowarr
This is a kapowarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8194
  - [x] https://kapowarr.tipi.lan
##### In app tests :
  - [x] 📝 Register to ComicVine
  - [x] 📚 Downloading metadata
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/kapowarr-db:/app/db
- [x] ${ROOT_FOLDER_HOST}/media/downloads/kapowarr:/app/temp_downloads
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
none