### PR TITLE
Add dynamic compose for zipline

### DIFF
--- a/apps/zipline/config.json
+++ b/apps/zipline/config.json
@@ -4,8 +4,9 @@
   "port": 8139,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "zipline",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "3.7.10",
   "categories": ["media"],
   "description": "A ShareX/file upload server that is easy to use, packed with features, and with an easy setup!  ",
@@ -29,5 +30,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1726186419000
+  "updated_at": 1734114409003
 }

--- a/apps/zipline/config.json
+++ b/apps/zipline/config.json
@@ -13,7 +13,7 @@
   "short_desc": "A ShareX/file upload server that is easy to use, packed with features, and with an easy setup!  ",
   "author": "https://github.com/diced",
   "source": "https://github.com/diced/zipline",
-  "website": "https://zipline.diced.tech/docs/config/",
+  "website": "https://zipline.diced.sh",
   "form_fields": [
     {
       "type": "random",

--- a/apps/zipline/docker-compose.json
+++ b/apps/zipline/docker-compose.json
@@ -1,0 +1,52 @@
+{
+  "services": [
+    {
+      "name": "zipline",
+      "image": "ghcr.io/diced/zipline:3.7.10",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "CORE_RETURN_HTTPS": "false",
+        "CORE_SECRET": "${ZIPLINE_CORE_SECRET}",
+        "CORE_HOST": "0.0.0.0",
+        "CORE_PORT": "3000",
+        "CORE_DATABASE_URL": "postgres://tipi:${ZIPLINE_DB_PASSWORD}@zipline-db/zipline",
+        "CORE_LOGGER": "true"
+      },
+      "dependsOn": [
+        "zipline-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uploads",
+          "containerPath": "/zipline/uploads"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/public",
+          "containerPath": "/zipline/public"
+        }
+      ]
+    },
+    {
+      "name": "zipline-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${ZIPLINE_DB_PASSWORD}",
+        "POSTGRES_DB": "zipline"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready -U postgres"
+      }
+    }
+  ]
+}

--- a/apps/zipline/docker-compose.json
+++ b/apps/zipline/docker-compose.json
@@ -13,9 +13,7 @@
         "CORE_DATABASE_URL": "postgres://tipi:${ZIPLINE_DB_PASSWORD}@zipline-db/zipline",
         "CORE_LOGGER": "true"
       },
-      "dependsOn": [
-        "zipline-db"
-      ],
+      "dependsOn": ["zipline-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/uploads",


### PR DESCRIPTION
## Dynamic compose for zipline
This is a zipline update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8139
  - [x] https://zipline.tipi.lan
##### In app tests :
  - [x] 📝 Login (check logs)
  - [x] 🌆 Uploading multiple files
  - [x] 🔗 Share link and check stats
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/uploads:/zipline/uploads
- [x] ${APP_DATA_DIR}/data/public:/zipline/public
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
​Specific instructions verified :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck