### PR TITLE
Add dynamic compose for code-server

### DIFF
--- a/apps/code-server/config.json
+++ b/apps/code-server/config.json
@@ -3,9 +3,10 @@
   "name": "Code Server",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8138,
   "id": "code-server",
-  "tipi_version": 44,
+  "tipi_version": 45,
   "version": "4.96.2",
   "categories": ["development"],
   "description": "Code-server is VS Code running on a remote server, accessible through the browser.",
@@ -32,5 +33,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734741681000
+  "updated_at": 1734908171200
 }

--- a/apps/code-server/docker-compose.json
+++ b/apps/code-server/docker-compose.json
@@ -1,0 +1,36 @@
+{
+  "services": [
+    {
+      "name": "code-server",
+      "image": "lscr.io/linuxserver/code-server:4.96.2",
+      "isMain": true,
+      "internalPort": 8443,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "PASSWORD": "${CODESERVER_PASSWORD}",
+        "SUDO_PASSWORD": "${CODESERVER_SUDO_PASSWORD}",
+        "DEFAULT_WORKSPACE": "/config/workspace"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/projects",
+          "containerPath": "/projects"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/app-data",
+          "containerPath": "/runtipi/app-data"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/user-config",
+          "containerPath": "/runtipi/user-config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for code-server
This is a code-server update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8138
  - [x] https://code-server.tipi.lan
##### In app tests :
  - [x] 🔓 Log in
  - [x] 📝 Write some files
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/projects:/projects
- [x] ${ROOT_FOLDER_HOST}/app-data:/runtipi/app-data
- [x] ${ROOT_FOLDER_HOST}/user-config:/runtipi/user-config
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the Code Server application.
	- Added a new Docker Compose configuration for the Code Server service, enhancing deployment capabilities.

- **Updates**
	- Incremented the version number for the application configuration.
	- Updated the timestamp for the configuration file to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->