### PR TITLE
Add dynamic compose for grocy

### DIFF
--- a/apps/grocy/config.json
+++ b/apps/grocy/config.json
@@ -3,7 +3,8 @@
   "name": "Grocy",
   "available": true,
   "exposable": true,
-  "tipi_version": 5,
+  "dynamic_config": true,
+  "tipi_version": 6,
   "version": "4.0.3",
   "port": 8136,
   "id": "grocy",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192
+  "updated_at": 1734908283891
 }

--- a/apps/grocy/docker-compose.json
+++ b/apps/grocy/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "services": [
+    {
+      "name": "grocy",
+      "image": "lscr.io/linuxserver/grocy:v4.0.3-ls215",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for grocy
This is a grocy update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8136
  - [x] https://grocy.tipi.lan
##### In app tests :
  - [x] 📝 Register 
  - [x] 🥕 Create entries with photos
  - [x] 🛒 Check groceries
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/config
##### Specific instructions verified :
- [x] 🌳 Environment (PUID=1000, PGID=1000, TZ=${TZ})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration for the Grocy application, including a new dynamic configuration option.
	- Introduced a new Docker Compose configuration for the Grocy service, enabling easier deployment.
  
- **Bug Fixes**
	- Updated versioning information for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->