### PR TITLE
Add dynamic compose for kavita

### DIFF
--- a/apps/kavita/config.json
+++ b/apps/kavita/config.json
@@ -4,8 +4,9 @@
   "port": 8175,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "kavita",
-  "tipi_version": 17,
+  "tipi_version": 18,
   "version": "0.8.4",
   "categories": ["media"],
   "description": "Kavita is a fast, feature rich, cross platform reading server",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1732321295000
+  "updated_at": 1734908347559
 }

--- a/apps/kavita/docker-compose.json
+++ b/apps/kavita/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "services": [
+    {
+      "name": "kavita",
+      "image": "jvmilazz0/kavita:0.8.4",
+      "isMain": true,
+      "internalPort": 5000,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/kavita-config",
+          "containerPath": "/kavita/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/books",
+          "containerPath": "/books"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/comics",
+          "containerPath": "/comics"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/manga",
+          "containerPath": "/manga"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for kavita
This is a kavita update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8175
  - [x] https://kavita.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 📚 Import Library
  - [x] 📖 Read books
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/kavita-config:/kavita/config
- [x] ${ROOT_FOLDER_HOST}/media/data/books:/books
- [x] ${ROOT_FOLDER_HOST}/media/data/comics:/comics
- [x] ${ROOT_FOLDER_HOST}/media/data/manga:/manga
##### Specific instructions verified :
- [x] 🌳 Environment (TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic configuration capability for the Kavita application.
  - Added a new Docker Compose configuration for the Kavita service, including volume mounts for media content.

- **Updates**
  - Incremented version number for the Kavita application.
  - Updated modification timestamp for the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->