### PR TITLE
Add dynamic compose for komga

### DIFF
--- a/apps/komga/config.json
+++ b/apps/komga/config.json
@@ -4,8 +4,9 @@
   "port": 2560,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "komga",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "1.15.1",
   "categories": ["media"],
   "description": "A media server for your comics, mangas, BDs, magazines and eBooks.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734430832000
+  "updated_at": 1734908364355
 }

--- a/apps/komga/docker-compose.json
+++ b/apps/komga/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "services": [
+    {
+      "name": "komga",
+      "image": "ghcr.io/gotson/komga:1.15.1",
+      "isMain": true,
+      "internalPort": 25600,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/data",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for komga
This is a komga update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:2560
  - [x] https://komga.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🔍 Scan Library
  - [x] 📓 Read comics
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/data:/data
##### Specific instructions verified :
- [x] 🌳 Environment (TZ)