### PR TITLE
Add dynamic compose for nodered

### DIFF
--- a/apps/nodered/config.json
+++ b/apps/nodered/config.json
@@ -4,8 +4,9 @@
   "port": 8111,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "nodered",
-  "tipi_version": 23,
+  "tipi_version": 24,
   "version": "4.0.8",
   "categories": ["automation"],
   "description": "Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways. It provides a browser-based editor that makes it easy to wire together flows using the wide range of nodes in the palette that can be deployed to its runtime in a single-click.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734716035000
+  "updated_at": 1734908489671
 }

--- a/apps/nodered/docker-compose.json
+++ b/apps/nodered/docker-compose.json
@@ -1,0 +1,16 @@
+{
+  "services": [
+    {
+      "name": "nodered",
+      "image": "nodered/node-red:4.0.8",
+      "isMain": true,
+      "internalPort": 1880,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for nodered
This is a nodered update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8111
  - [x] https://nodered.tipi.lan
##### In app tests :
  - [x] ⛓ Create some workflows
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/data
##### Specific instructions verified :
none