### PR TITLE
Add dynamic compose for pingvin-share

### DIFF
--- a/apps/pingvin-share/config.json
+++ b/apps/pingvin-share/config.json
@@ -8,13 +8,14 @@
   "port": 8654,
   "categories": ["data", "utilities"],
   "description": "A self-hosted file sharing platform that combines lightness and beauty, perfect for seamless and efficient file sharing",
-  "tipi_version": 15,
+  "tipi_version": 16,
   "version": "1.7.0",
   "source": "https://github.com/stonith404/pingvin-share",
   "website": "https://pingvin-share.dev.eliasschneider.com",
   "exposable": true,
+  "dynamic_config": true,
   "supported_architectures": ["arm64", "amd64"],
   "form_fields": [],
   "created_at": 1691943801422,
-  "updated_at": 1734672129000
+  "updated_at": 1734908555220
 }

--- a/apps/pingvin-share/docker-compose.json
+++ b/apps/pingvin-share/docker-compose.json
@@ -1,0 +1,20 @@
+{
+  "services": [
+    {
+      "name": "pingvin-share",
+      "image": "stonith404/pingvin-share:v1.7.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/opt/app/backend/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/images",
+          "containerPath": "/opt/app/frontend/public/img"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for pingvin-share
This is a pingvin-share update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8654
  - [x] https://pingvin-share.tipi.lan
##### In app tests :
  - [x] 📜 Register
  - [x] 🌆 Uploading data
  - [x] 🔗 Share link
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/opt/app/backend/data
- [x] ${APP_DATA_DIR}/data/images:/opt/app/frontend/public/img
##### Specific instructions verified :
none