### PR TITLE
Add dynamic compose for planning-poker

### DIFF
--- a/apps/planning-poker/config.json
+++ b/apps/planning-poker/config.json
@@ -4,8 +4,9 @@
   "port": 8880,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "planning-poker",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "1.2.1",
   "categories": ["development"],
   "description": "",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["amd64", "arm64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1734908563647
 }

--- a/apps/planning-poker/docker-compose.json
+++ b/apps/planning-poker/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "services": [
+    {
+      "name": "planning-poker",
+      "image": "axeleroy/self-host-planning-poker:1.2.1",
+      "isMain": true,
+      "internalPort": 8000,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "wget --no-verbose --tries=1 --spider http://127.0.0.1:8000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for planning-poker
This is a planning-poker update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8880
  - [x] https://planning-poker.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🕹 Invite other to play
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/data
##### Specific instructions verified :
- [x] 🩺 Healthcheck