### PR TITLE
Add dynamic compose for ryot

### DIFF
--- a/apps/ryot/config.json
+++ b/apps/ryot/config.json
@@ -4,8 +4,9 @@
   "port": 8206,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "ryot",
-  "tipi_version": 25,
+  "tipi_version": 26,
   "version": "2.24.2",
   "categories": ["media"],
   "description": "Roll your own tracker!",
@@ -44,5 +45,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1734908651396
 }

--- a/apps/ryot/docker-compose.json
+++ b/apps/ryot/docker-compose.json
@@ -12,9 +12,7 @@
         "VIDEO_GAMES_TWITCH_CLIENT_ID": "${RYOT_VIDEO_GAMES_TWITCH_CLIENT_ID}",
         "VIDEO_GAMES_TWITCH_CLIENT_SECRET": " ${VIDEO_GAMES_TWITCH_CLIENT_SECRET}"
       },
-      "dependsOn": [
-        "ryot-db"
-      ]
+      "dependsOn": ["ryot-db"]
     },
     {
       "name": "ryot-db",

--- a/apps/ryot/docker-compose.json
+++ b/apps/ryot/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "services": [
+    {
+      "name": "ryot",
+      "image": "ghcr.io/ignisda/ryot:v2.24.2",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "DATABASE_URL": "postgres://tipi:${RYOT_DB_PASSWORD}@ryot-db:5432/ryot",
+        "SERVER_INSECURE_COOKIE": "true",
+        "USERS_ALLOW_REGISTRATION": "${RYOT_ALLOW_REGISTRATION}",
+        "VIDEO_GAMES_TWITCH_CLIENT_ID": "${RYOT_VIDEO_GAMES_TWITCH_CLIENT_ID}",
+        "VIDEO_GAMES_TWITCH_CLIENT_SECRET": " ${VIDEO_GAMES_TWITCH_CLIENT_SECRET}"
+      },
+      "dependsOn": [
+        "ryot-db"
+      ]
+    },
+    {
+      "name": "ryot-db",
+      "image": "postgres:15-alpine",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${RYOT_DB_PASSWORD}",
+        "POSTGRES_DB": "ryot"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for ryot
This is a ryot update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8206
  - [x] https://ryot.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 📊 Add differents things to track in diverse collections
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] {APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment