### PR TITLE
Add dynamic compose for wekan

### DIFF
--- a/apps/wekan/config.json
+++ b/apps/wekan/config.json
@@ -4,8 +4,9 @@
   "port": 8678,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "wekan",
-  "tipi_version": 42,
+  "tipi_version": 43,
   "version": "7.72",
   "categories": ["development"],
   "description": "Experience efficient task management with WeKan - the Open-Source, customizable, and privacy-focused kanban",
@@ -30,5 +31,5 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733634425000
+  "updated_at": 1734908810846
 }

--- a/apps/wekan/docker-compose.json
+++ b/apps/wekan/docker-compose.json
@@ -1,0 +1,50 @@
+{
+  "services": [
+    {
+      "name": "wekan",
+      "image": "ghcr.io/wekan/wekan:v7.72",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "MONGO_URL": "mongodb://wekan-db:27017/wekan",
+        "ROOT_URL": "https://${APP_DOMAIN}",
+        "MAIL_URL": "smtp://${MAIL_ADDRESS}:${MAIL_PASSWORD}@smtp.gmail.com:587",
+        "MAIL_FROM": "Wekan Notifications <noreply.wekan@${APP_DOMAIN}>"
+      },
+      "dependsOn": [
+        "wekan-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/wekan",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "wekan-db",
+      "image": "mongo:6",
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mongo",
+          "containerPath": "/data/db"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/dump",
+          "containerPath": "/dump"
+        }
+      ],
+      "command": "mongod --logpath /dev/null --oplogSize 128 --quiet"
+    }
+  ]
+}

--- a/apps/wekan/docker-compose.json
+++ b/apps/wekan/docker-compose.json
@@ -11,9 +11,7 @@
         "MAIL_URL": "smtp://${MAIL_ADDRESS}:${MAIL_PASSWORD}@smtp.gmail.com:587",
         "MAIL_FROM": "Wekan Notifications <noreply.wekan@${APP_DOMAIN}>"
       },
-      "dependsOn": [
-        "wekan-db"
-      ],
+      "dependsOn": ["wekan-db"],
       "volumes": [
         {
           "hostPath": "/etc/localtime",


### PR DESCRIPTION
## Dynamic compose for wekan
This is a wekan update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8678
  - [x] https://wekan.tipi.lan
  - [x] https://wekan.domain.com
##### In app tests :
  - [x] 📝 Register
  - [x] 📊 Create Project
  - [x] 🌆 Upload attachments
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/wekan:/data
- [x] ${APP_DATA_DIR}/data/mongo:/data/db
- [x] ${APP_DATA_DIR}/data/dump:/dump
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command