### PR TITLE
Add dynamic compose for mixpost

### DIFF
--- a/apps/mixpost/config.json
+++ b/apps/mixpost/config.json
@@ -4,8 +4,9 @@
   "port": 8167,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "mixpost",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "1.7.2",
   "categories": ["social"],
   "description": "Mixpost it's the coolest Self-hosted social media management software.",
@@ -36,5 +37,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723905317000
+  "updated_at": 1734908431368
 }

--- a/apps/mixpost/docker-compose.json
+++ b/apps/mixpost/docker-compose.json
@@ -1,0 +1,76 @@
+{
+  "services": [
+    {
+      "name": "mixpost",
+      "image": "inovector/mixpost:v1.7.2",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "APP_NAME": "'Mixpost'",
+        "APP_KEY": "'${MIXPOST_APP_KEY}'",
+        "APP_URL": "'${APP_PROTOCOL:-http}://${APP_DOMAIN}'",
+        "DB_HOST": "mixpost-mysql",
+        "DB_DATABASE": "mixpost",
+        "DB_USERNAME": "tipi",
+        "DB_PASSWORD": "${MIXPOST_MYSQL_PASSWORD}",
+        "REDIS_HOST": "mixpost-redis",
+        "REDIS_PASSWORD": "${MIXPOST_REDIS_PASSWORD}"
+      },
+      "dependsOn": [
+        "mixpost-mysql",
+        "mixpost-redis"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mixpost-storage",
+          "containerPath": "/var/www/html/storage/app"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mixpost-logs",
+          "containerPath": "/var/www/html/storage/logs"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nginx/nginx.conf",
+          "containerPath": "/etc/nginx/sites-enabled/default"
+        }
+      ]
+    },
+    {
+      "name": "mixpost-mysql",
+      "image": "mysql/mysql-server:8.0",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "${MIXPOST_MYSQL_PASSWORD}",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${MIXPOST_MYSQL_PASSWORD}",
+        "MYSQL_DATABASE": "mixpost"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "mysqladmin ping -p ${MIXPOST_MYSQL_PASSWORD}"
+      }
+    },
+    {
+      "name": "mixpost-redis",
+      "image": "redis:latest",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "redis-server --appendonly yes --replica-read-only no --requirepass \"${MIXPOST_REDIS_PASSWORD}\"",
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}

--- a/apps/mixpost/docker-compose.json
+++ b/apps/mixpost/docker-compose.json
@@ -16,10 +16,7 @@
         "REDIS_HOST": "mixpost-redis",
         "REDIS_PASSWORD": "${MIXPOST_REDIS_PASSWORD}"
       },
-      "dependsOn": [
-        "mixpost-mysql",
-        "mixpost-redis"
-      ],
+      "dependsOn": ["mixpost-mysql", "mixpost-redis"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/mixpost-storage",
@@ -65,7 +62,7 @@
           "containerPath": "/data"
         }
       ],
-      "command": "redis-server --appendonly yes --replica-read-only no --requirepass \"${MIXPOST_REDIS_PASSWORD}\"",
+      "command": "redis-server --appendonly yes --replica-read-only no --requirepass ${MIXPOST_REDIS_PASSWORD}",
       "healthCheck": {
         "timeout": "5s",
         "retries": 3,


### PR DESCRIPTION
## Dynamic compose for mixpost
This is a mixpost update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8167
  - [x] https://mixpost.tipi.lan
##### In app tests :
  - [x] 📝 Login
  - [x] 🔓 Configure social API
  - [x] 📅 Schedule a post
  - [x] 📱 Check result on social media
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/mixpost-storage:/var/www/html/storage/app
- [x] ${APP_DATA_DIR}/data/mixpost-logs:/var/www/html/storage/logs
- [x] ${APP_DATA_DIR}/data/nginx/nginx.conf:/etc/nginx/sites-enabled/default
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration support in the Mixpost application.
	- Added a new Docker Compose setup with three services: Mixpost, MySQL, and Redis.

- **Updates**
	- Incremented application version from 14 to 15.
	- Updated configuration timestamp to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->