### PR TITLE
Add dynamic compose for getashell

### DIFF
--- a/apps/getashell/config.json
+++ b/apps/getashell/config.json
@@ -3,9 +3,10 @@
   "name": "Get A Shell",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8281,
   "id": "getashell",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "1.1.3",
   "categories": ["utilities"],
   "description": "Simple web ui to create ssh shells for testing.",
@@ -34,5 +35,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1725904870000
+  "updated_at": 1734908260001
 }

--- a/apps/getashell/docker-compose.json
+++ b/apps/getashell/docker-compose.json
@@ -5,9 +5,7 @@
       "image": "ghcr.io/steveiliop56/getashell:v1.1.3",
       "isMain": true,
       "internalPort": 3000,
-      "extraHosts": [
-        "host.docker.internal:host-gateway"
-      ],
+      "extraHosts": ["host.docker.internal:host-gateway"],
       "environment": {
         "USERNAME": "${GETASHELL_USERNAME}",
         "PASSWORD": "${GETASHELL_PASSWORD}",

--- a/apps/getashell/docker-compose.json
+++ b/apps/getashell/docker-compose.json
@@ -1,0 +1,29 @@
+{
+  "services": [
+    {
+      "name": "getashell",
+      "image": "ghcr.io/steveiliop56/getashell:v1.1.3",
+      "isMain": true,
+      "internalPort": 3000,
+      "extraHosts": [
+        "host.docker.internal:host-gateway"
+      ],
+      "environment": {
+        "USERNAME": "${GETASHELL_USERNAME}",
+        "PASSWORD": "${GETASHELL_PASSWORD}",
+        "SECRET_KEY": "${GETASHELL_SECRET_KEY}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/",
+          "containerPath": "/app/data"
+        },
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock",
+          "readOnly": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for getashell
This is a getashell update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8281
  - [x] https://getashell.tipi.lan
- [x] Access shell
##### In app tests :
- [x] 📝 Register and log in
- [x] 🐚 Create a shell
- [x] 🐢 SSH into it
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/:/app/data
- [x] /var/run/docker.sock:/var/run/docker.sock:ro
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic configuration capabilities for the "Get A Shell" application.
	- Updated versioning to reflect the latest changes.
	- Added a new Docker Compose configuration for the `getashell` service, including environment variable support and volume mappings.

- **Bug Fixes**
	- Updated timestamps to reflect the most recent configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->