### PR TITLE
Add dynamic compose for chatgpt UI

### DIFF
--- a/apps/chatgpt-ui/config.json
+++ b/apps/chatgpt-ui/config.json
@@ -4,8 +4,9 @@
   "port": 8200,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "chatgpt-ui",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "2.5.9",
   "categories": ["ai"],
   "description": "A ChatGPT web client that supports multiple users, multiple languages, and multiple database connections for persistent data storage",
@@ -44,5 +45,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1734908161108
 }

--- a/apps/chatgpt-ui/docker-compose.json
+++ b/apps/chatgpt-ui/docker-compose.json
@@ -1,0 +1,72 @@
+{
+  "services": [
+    {
+      "name": "chatgpt-ui",
+      "image": "wongsaang/chatgpt-ui-client:v2.5.9",
+      "isMain": true,
+      "addPorts": [
+        {
+          "hostPort": 8200,
+          "containerPort": 80
+        }
+      ],
+      "environment": {
+        "SERVER_DOMAIN": "http://chatgpt-ui-web-server",
+        "DEFAULT_LOCALE": "en"
+      },
+      "dependsOn": [
+        "chatgpt-ui-web-server"
+      ]
+    },
+    {
+      "name": "chatgpt-ui-wsgi-server",
+      "image": "wongsaang/chatgpt-ui-wsgi-server:v2.5.2",
+      "environment": {
+        "APP_DOMAIN": "${INTERNAL_IP}:8201",
+        "SERVER_WORKERS": "3",
+        "WORKER_TIMEOUT": "180",
+        "DB_URL": "mysql://tipi:${CHATGPT_UI_DB_PASSWORD}@chatgpt-ui-db:3306/chatgptdb",
+        "DJANGO_SUPERUSER_USERNAME": "${CHATGPT_UI_SUPERUSER_USERNAME}",
+        "DJANGO_SUPERUSER_PASSWORD": "${CHATGPT_UI_SUPERUSER_PASSWORD}",
+        "DJANGO_SUPERUSER_EMAIL": "${CHATGPT_UI_SUPERUSER_EMAIL}",
+        "ACCOUNT_EMAIL_VERIFICATION": "none"
+      },
+      "dependsOn": [
+        "chatgpt-ui-db"
+      ]
+    },
+    {
+      "name": "chatgpt-ui-web-server",
+      "image": "wongsaang/chatgpt-ui-web-server:v2.5.2",
+      "addPorts": [
+        {
+          "hostPort": 8201,
+          "containerPort": 80
+        }
+      ],
+      "environment": {
+        "BACKEND_URL": "http://chatgpt-ui-wsgi-server:8000"
+      },
+      "dependsOn": [
+        "chatgpt-ui-wsgi-server",
+        "chatgpt-ui-db"
+      ]
+    },
+    {
+      "name": "chatgpt-ui-db",
+      "image": "lscr.io/linuxserver/mariadb:latest",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "$CHATGPT_UI_DB_PASSWORD}",
+        "MYSQL_DATABASE": "chatgptdb",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${CHATGPT_UI_DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/chatgpt-ui/docker-compose.json
+++ b/apps/chatgpt-ui/docker-compose.json
@@ -4,19 +4,13 @@
       "name": "chatgpt-ui",
       "image": "wongsaang/chatgpt-ui-client:v2.5.9",
       "isMain": true,
-      "addPorts": [
-        {
-          "hostPort": 8200,
-          "containerPort": 80
-        }
+      "internalPort": 80
       ],
       "environment": {
         "SERVER_DOMAIN": "http://chatgpt-ui-web-server",
         "DEFAULT_LOCALE": "en"
       },
-      "dependsOn": [
-        "chatgpt-ui-web-server"
-      ]
+      "dependsOn": ["chatgpt-ui-web-server"]
     },
     {
       "name": "chatgpt-ui-wsgi-server",
@@ -31,9 +25,7 @@
         "DJANGO_SUPERUSER_EMAIL": "${CHATGPT_UI_SUPERUSER_EMAIL}",
         "ACCOUNT_EMAIL_VERIFICATION": "none"
       },
-      "dependsOn": [
-        "chatgpt-ui-db"
-      ]
+      "dependsOn": ["chatgpt-ui-db"]
     },
     {
       "name": "chatgpt-ui-web-server",
@@ -47,10 +39,7 @@
       "environment": {
         "BACKEND_URL": "http://chatgpt-ui-wsgi-server:8000"
       },
-      "dependsOn": [
-        "chatgpt-ui-wsgi-server",
-        "chatgpt-ui-db"
-      ]
+      "dependsOn": ["chatgpt-ui-wsgi-server", "chatgpt-ui-db"]
     },
     {
       "name": "chatgpt-ui-db",

--- a/apps/chatgpt-ui/docker-compose.json
+++ b/apps/chatgpt-ui/docker-compose.json
@@ -5,7 +5,6 @@
       "image": "wongsaang/chatgpt-ui-client:v2.5.9",
       "isMain": true,
       "internalPort": 80
-      ],
       "environment": {
         "SERVER_DOMAIN": "http://chatgpt-ui-web-server",
         "DEFAULT_LOCALE": "en"

--- a/apps/chatgpt-ui/docker-compose.json
+++ b/apps/chatgpt-ui/docker-compose.json
@@ -44,7 +44,7 @@
       "name": "chatgpt-ui-db",
       "image": "lscr.io/linuxserver/mariadb:latest",
       "environment": {
-        "MYSQL_ROOT_PASSWORD": "$CHATGPT_UI_DB_PASSWORD}",
+        "MYSQL_ROOT_PASSWORD": "${CHATGPT_UI_DB_PASSWORD}",
         "MYSQL_DATABASE": "chatgptdb",
         "MYSQL_USER": "tipi",
         "MYSQL_PASSWORD": "${CHATGPT_UI_DB_PASSWORD}"

--- a/apps/chatgpt-ui/docker-compose.json
+++ b/apps/chatgpt-ui/docker-compose.json
@@ -4,7 +4,7 @@
       "name": "chatgpt-ui",
       "image": "wongsaang/chatgpt-ui-client:v2.5.9",
       "isMain": true,
-      "internalPort": 80
+      "internalPort": 80,
       "environment": {
         "SERVER_DOMAIN": "http://chatgpt-ui-web-server",
         "DEFAULT_LOCALE": "en"


### PR DESCRIPTION
## Dynamic compose for chatgpt-ui
This is a chatgpt-ui update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8200
  - [x] https://chatgpt-ui.tipi.lan
- [x] Additionnals ports are mapped correctly
  - [x] http://localip:8201/admin
##### In app tests :
  - [x] 📝 Register and log in
  - [x] ⚙ Access Django admin interface and set up OpenAI API key
  - [x] 🌆 Basic talk wiht ChatGPT
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/mysql/config:/config
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for dynamic configuration in the ChatGPT UI.
	- Added a multi-service architecture with a new Docker Compose configuration for the ChatGPT UI application, including services for the main application, WSGI server, web server, and database.

- **Updates**
	- Incremented version number for the application configuration.
	- Updated the last modified timestamp for the configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->