### PR TITLE
Add dynamic compose for calcom

### DIFF
--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -4,6 +4,7 @@
   "categories": ["social"],
   "description": "The open source Calendly successor. You are in charge of your own data, workflow, and appearance.\nCalendly and other scheduling tools are awesome. It made our lives massively easier. We're using it for business meetings, seminars, yoga classes, and even calls with our families. However, most tools are very limited in terms of control and customization.\n    That's where Cal.com comes in. Self-hosted or hosted by us. White-label by design. API-driven and ready to be deployed on your own domain. Full control of your events and data.",
   "exposable": true,
+  "dynamic_config": true,
   "form_fields": [
     {
       "env_variable": "CALCOM_NEXTAUTH_SECRET",
@@ -105,9 +106,9 @@
   "short_desc": "Scheduling infrastructure for absolutely everyone.",
   "source": "https://github.com/calcom/cal.com",
   "supported_architectures": ["amd64"],
-  "tipi_version": 57,
+  "tipi_version": 58,
   "version": "4.7.8",
   "website": "https://cal.com/",
   "created_at": 1691943801422,
-  "updated_at": 1732297007000
+  "updated_at": 1735481888778
 }

--- a/apps/calcom/docker-compose.json
+++ b/apps/calcom/docker-compose.json
@@ -1,0 +1,52 @@
+{
+  "services": [
+    {
+      "name": "calcom",
+      "image": "calcom/cal.com:v4.7.8",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "DATABASE_HOST": "db-calcom",
+        "DATABASE_URL": "postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@db-calcom/calcom",
+        "DATABASE_DIRECT_URL": "postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@db-calcom/calcom",
+        "POSTGRES_USER": "${POSTGRES_USERNAME}",
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+        "POSTGRES_DB": "calcom",
+        "LICENSE": "agree",
+        "NEXT_PUBLIC_LICENSE_CONSENT": "agree",
+        "NEXT_PUBLIC_WEBAPP_URL": "https://${APP_DOMAIN}",
+        "NEXTAUTH_SECRET": "${CALCOM_NEXTAUTH_SECRET}",
+        "CALENDSO_ENCRYPTION_KEY": "${CALENDSO_ENCRYPTION_KEY}",
+        "MS_GRAPH_CLIENT_ID": "${MS_GRAPH_CLIENT_ID}",
+        "MS_GRAPH_CLIENT_SECRET": "${MS_GRAPH_CLIENT_SECRET}",
+        "ZOOM_CLIENT_ID": "${ZOOM_CLIENT_ID}",
+        "ZOOM_CLIENT_SECRET": "${ZOOM_CLIENT_SECRET}",
+        "GOOGLE_API_CREDENTIALS": "${CALCOM_GOOGLE_API_CREDENTIALS}",
+        "EMAIL_FROM": "${EMAIL_FROM}",
+        "EMAIL_SERVER_HOST": "${EMAIL_SERVER_HOST}",
+        "EMAIL_SERVER_PORT": "${EMAIL_SERVER_PORT}",
+        "EMAIL_SERVER_PASSWORD": "${EMAIL_SERVER_PASSWORD}",
+        "EMAIL_SERVER_USER": "${EMAIL_SERVER_USER}",
+        "NODE_ENV": "production"
+      },
+      "dependsOn": [
+        "db-calcom"
+      ]
+    },
+    {
+      "name": "db-calcom",
+      "image": "postgres:16.1",
+      "environment": {
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+        "POSTGRES_USER": "${POSTGRES_USERNAME}",
+        "POSTGRES_DB": "calcom"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/calcom/docker-compose.json
+++ b/apps/calcom/docker-compose.json
@@ -29,9 +29,7 @@
         "EMAIL_SERVER_USER": "${EMAIL_SERVER_USER}",
         "NODE_ENV": "production"
       },
-      "dependsOn": [
-        "db-calcom"
-      ]
+      "dependsOn": ["db-calcom"]
     },
     {
       "name": "db-calcom",


### PR DESCRIPTION
## Dynamic compose for calcom
This is a calcom update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8294
  - [x] https://calcom.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 📆 add external calendar
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in Cal.com
	- Introduced Docker Compose configuration for Cal.com and its database

- **Chores**
	- Updated Tipi version from 57 to 58
	- Updated configuration timestamp
	- Configured Cal.com application with version v4.7.8 and PostgreSQL 16.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->