### PR TITLE
Add dynamic compose for calibre-web

### DIFF
--- a/apps/calibre-web/config.json
+++ b/apps/calibre-web/config.json
@@ -3,8 +3,9 @@
   "name": "Calibre-Web - EBook Reader",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8100,
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "0.6.24",
   "id": "calibre-web",
   "categories": ["books"],
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731754541000
+  "updated_at": 1735481892914
 }

--- a/apps/calibre-web/docker-compose.json
+++ b/apps/calibre-web/docker-compose.json
@@ -1,0 +1,25 @@
+{
+  "services": [
+    {
+      "name": "calibre-web",
+      "image": "lscr.io/linuxserver/calibre-web:0.6.24",
+      "isMain": true,
+      "internalPort": 8083,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/books",
+          "containerPath": "/books"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for calibre-web
This is a calibre-web update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8100
  - [x] https://calibre-web.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 📚 Scan library
  - [x] 📖 Read book
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${ROOT_FOLDER_HOST}/media/data/books:/books
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, PGID, TZ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Added dynamic configuration support for Calibre-Web
  - Updated Tipi version to 12
  - Updated configuration timestamp

- **Docker Configuration**
  - Added Docker Compose configuration for Calibre-Web service
  - Configured with latest Calibre-Web image (0.6.24)
  - Set up volume mappings for configuration and books directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->