### PR TITLE
Add dynamic compose for ctfd

### DIFF
--- a/apps/ctfd/config.json
+++ b/apps/ctfd/config.json
@@ -4,8 +4,9 @@
   "port": 8546,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "ctfd",
-  "tipi_version": 7,
+  "tipi_version": 8,
   "version": "3.7.5",
   "categories": ["utilities"],
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability.",
@@ -35,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735359410000
+  "updated_at": 1735481922294
 }

--- a/apps/ctfd/docker-compose.json
+++ b/apps/ctfd/docker-compose.json
@@ -43,13 +43,7 @@
           "containerPath": "/var/lib/mysql"
         }
       ],
-      "command": [
-        "mysqld",
-        "--character-set-server=utf8mb4",
-        "--collation-server=utf8mb4_unicode_ci",
-        "--wait_timeout=28800",
-        "--log-warnings=0"
-      ]
+      "command": ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--wait_timeout=28800", "--log-warnings=0"]
     },
     {
       "name": "ctfd-redis",

--- a/apps/ctfd/docker-compose.json
+++ b/apps/ctfd/docker-compose.json
@@ -1,0 +1,67 @@
+{
+  "services": [
+    {
+      "name": "ctfd",
+      "image": "ctfd/ctfd:3.7.5",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "UPLOAD_FOLDER": "/var/uploads",
+        "DATABASE_URL": "mysql+pymysql://tipi:${CTFD_MYSQL_DB_PASSWORD}@ctfd-db/ctfd",
+        "REDIS_URL": "redis://ctfd-redis:6379",
+        "WORKERS": "1",
+        "LOG_FOLDER": "/var/log/CTFd",
+        "ACCESS_LOG": "-",
+        "ERROR_LOG": "-",
+        "REVERSE_PROXY": "true",
+        "SECRET_KEY": "${CTFD_SECRET_KEY}"
+      },
+      "dependsOn": [
+        "ctfd-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uploads",
+          "containerPath": "/var/log/CTFd"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uploads",
+          "containerPath": "/var/uploads"
+        }
+      ]
+    },
+    {
+      "name": "ctfd-db",
+      "image": "mariadb:10.4.12",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "${CTFD_MYSQL_ROOT_PASSWORD}",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${CTFD_MYSQL_DB_PASSWORD}",
+        "MYSQL_DATABASE": "ctfd"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "command": [
+        "mysqld",
+        "--character-set-server=utf8mb4",
+        "--collation-server=utf8mb4_unicode_ci",
+        "--wait_timeout=28800",
+        "--log-warnings=0"
+      ]
+    },
+    {
+      "name": "ctfd-redis",
+      "image": "redis:4",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/ctfd/docker-compose.json
+++ b/apps/ctfd/docker-compose.json
@@ -16,9 +16,7 @@
         "REVERSE_PROXY": "true",
         "SECRET_KEY": "${CTFD_SECRET_KEY}"
       },
-      "dependsOn": [
-        "ctfd-db"
-      ],
+      "dependsOn": ["ctfd-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/uploads",


### PR DESCRIPTION
## Dynamic compose for ctfd
This is a ctfd update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8546
  - [x] https://ctfd.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🏁 Create competition
  - [x] 🚩 Create a challenge
  - [x] 🔗 Upload files inside
  - [x] 🏁 Resolve a CTF
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/uploads:/var/log/CTFd
- [x] ${APP_DATA_DIR}/data/uploads:/var/uploads
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration for CTFd
	- Updated CTFd to version 3.7.5
	- Added supporting database (MariaDB) and cache (Redis) services

- **Chores**
	- Incremented application version from 7 to 8
	- Updated configuration timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->