### PR TITLE
Add dynamic compose for librephotos

### DIFF
--- a/apps/librephotos/config.json
+++ b/apps/librephotos/config.json
@@ -4,8 +4,9 @@
   "port": 8132,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "librephotos",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "2023w48",
   "categories": ["photography"],
   "description": "Complete photo management service",
@@ -48,5 +49,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1735482096388
 }

--- a/apps/librephotos/docker-compose.json
+++ b/apps/librephotos/docker-compose.json
@@ -1,0 +1,106 @@
+{
+  "services": [
+    {
+      "name": "librephotos",
+      "image": "reallibrephotos/librephotos-proxy:2023w48",
+      "isMain": true,
+      "internalPort": 80,
+      "dependsOn": [
+        "librephotos-backend",
+        "librephotos-frontend"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/scan",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/protected_media",
+          "containerPath": "/protected_media"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/proxy/nginx.conf",
+          "containerPath": "/etc/nginx/nginx.conf",
+          "readOnly": true
+        }
+      ]
+    },
+    {
+      "name": "librephotos-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_PASSWORD": "${LIBREPHOTOS_DB_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "librephotos"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "5s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
+      }
+    },
+    {
+      "name": "librephotos-frontend",
+      "image": "reallibrephotos/librephotos-frontend:2023w48",
+      "dependsOn": [
+        "librephotos-backend"
+      ]
+    },
+    {
+      "name": "librephotos-backend",
+      "image": "reallibrephotos/librephotos:2023w48",
+      "environment": {
+        "SECRET_KEY": "${LIBREPHOTOS_SECRET_KEY}",
+        "BACKEND_HOST": "librephotos-backend",
+        "ADMIN_EMAIL": "${LIBREPHOTOS_EMAIL}",
+        "ADMIN_USERNAME": "${LIBREPHOTOS_USERNAME}",
+        "ADMIN_PASSWORD": "${LIBREPHOTOS_PASSWORD}",
+        "DB_BACKEND": "postgresql",
+        "DB_NAME": "librephotos",
+        "DB_USER": "tipi",
+        "DB_PASS": "${LIBREPHOTOS_DB_PASSWORD}",
+        "DB_HOST": "librephotos-db",
+        "DB_PORT": "5432",
+        "REDIS_HOST": "librephotos-redis",
+        "REDIS_PORT": "6379",
+        "ALLOW_UPLOAD": "true",
+        "DEBUG": "0",
+        "CSRF_TRUSTED_ORIGINS": "${APP_PROTOCOL:-http}://${APP_DOMAIN},http://${INTERNAL_IP}:${APP_PORT}"
+      },
+      "dependsOn": {
+        "librephotos-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/scan",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/protected_media",
+          "containerPath": "/protected_media"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/logs",
+          "containerPath": "/logs"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/cache",
+          "containerPath": "/root/.cache"
+        }
+      ]
+    },
+    {
+      "name": "librephotos-redis",
+      "image": "redis:6"
+    }
+  ]
+}

--- a/apps/librephotos/docker-compose.json
+++ b/apps/librephotos/docker-compose.json
@@ -5,10 +5,7 @@
       "image": "reallibrephotos/librephotos-proxy:2023w48",
       "isMain": true,
       "internalPort": 80,
-      "dependsOn": [
-        "librephotos-backend",
-        "librephotos-frontend"
-      ],
+      "dependsOn": ["librephotos-backend", "librephotos-frontend"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/scan",
@@ -49,9 +46,7 @@
     {
       "name": "librephotos-frontend",
       "image": "reallibrephotos/librephotos-frontend:2023w48",
-      "dependsOn": [
-        "librephotos-backend"
-      ]
+      "dependsOn": ["librephotos-backend"]
     },
     {
       "name": "librephotos-backend",


### PR DESCRIPTION
## Dynamic compose for librephotos
This is a librephotos update for using dynamic compose. (no other change)
##### Situation tested :
- 💾 Update on existing data
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8132
  - [x] https://librephotos.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🌆 Upload images
  - [x] 😀 Check faces detection
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/scan:/data
- [x] ${APP_DATA_DIR}/data/protected_media:/protected_media
- [x] ${APP_DATA_DIR}/data/proxy/nginx.conf:/etc/nginx/nginx.conf:ro
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/logs:/logs
- [x] ${APP_DATA_DIR}/data/cache:/root/.cache
##### Specific instructions verified :
- [x] 🌳 Environment 
- [x] 🩺 Healthcheck