### PR TITLE
Add dynamic compose for n8n (v0)

### DIFF
--- a/apps/n8n/config.json
+++ b/apps/n8n/config.json
@@ -3,10 +3,11 @@
   "name": "n8n (v0)",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "deprecated": true,
   "port": 8094,
   "id": "n8n",
-  "tipi_version": 27,
+  "tipi_version": 28,
   "version": "0.237.0",
   "categories": ["automation"],
   "description": "n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, be available to self-host, and allow you to add your own custom functions, logic and apps. n8n's node-based approach makes it highly versatile, enabling you to connect anything to everything.",
@@ -17,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1735482182629
 }

--- a/apps/n8n/docker-compose.json
+++ b/apps/n8n/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "services": [
+    {
+      "name": "n8n",
+      "image": "n8nio/n8n:0.237.0",
+      "isMain": true,
+      "internalPort": 5678,
+      "environment": {
+        "N8N_EDITOR_BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "WEBHOOK_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/n8n",
+          "containerPath": "/home/node/.n8n"
+        }
+      ],
+      "command": "/bin/sh -c \"sleep 5; n8n start\""
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for n8n (v0)
This is a n8n update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8094
  - [x] https://n8n.tipi.lan (refused but works)
##### In app tests :
  - [x] 📝 Register and log in
  - [x] ⚙ Create a workflow
  - [x] 🌐 Call workflow with webhook
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/n8n:/home/node/.n8n
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command
