### PR TITLE
Add dynamic compose for owncast

### DIFF
--- a/apps/owncast/config.json
+++ b/apps/owncast/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "port": 8198,
   "exposable": true,
+  "dynamic_config": true,
   "id": "owncast",
   "description": "Owncast is an open source, self-hosted, decentralized, single user live video streaming and chat server for running your own live streams similar in style to the large mainstream options. It offers complete ownership over your content, interface, moderation and audience.",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "0.1.3",
   "categories": ["media"],
   "short_desc": " Take control over your live stream video by running it yourself. Streaming + chat out of the box. ",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1735482256679
 }

--- a/apps/owncast/docker-compose.json
+++ b/apps/owncast/docker-compose.json
@@ -1,0 +1,22 @@
+{
+  "services": [
+    {
+      "name": "owncast",
+      "image": "owncast/owncast:0.1.3",
+      "isMain": true,
+      "internalPort": 8080,
+      "addPorts": [
+        {
+          "hostPort": 1935,
+          "containerPort": 1935
+        }
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/app/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for owncast
This is a owncast update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8198
  - [x] https://owncast.tipi.lan
- [x] Additionnals ports are mapped correctly
  - [x] 1935:1935 (rtmp)
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🌆 Stream from OBS into Owncast
  - [x] 💬 Send messages
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/app/data
##### Specific instructions verified :
none