### PR TITLE
Add dynamic compose for shlink

### DIFF
--- a/apps/shlink/config.json
+++ b/apps/shlink/config.json
@@ -3,10 +3,11 @@
   "name": "Shlink",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "force_expose": true,
   "port": 8207,
   "id": "shlink",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "4.4.0",
   "categories": ["utilities"],
   "description": "Shlink is a self-hosted URL shortener which provides both a REST and a CLI interface to interact with it.",
@@ -24,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735321997000
+  "updated_at": 1735482408809
 }

--- a/apps/shlink/docker-compose.json
+++ b/apps/shlink/docker-compose.json
@@ -14,9 +14,7 @@
         "DB_USER": "shlink",
         "DB_PASSWORD": "${SHLINK_POSTGRES_PASSWORD}"
       },
-      "dependsOn": [
-        "shlink-db"
-      ]
+      "dependsOn": ["shlink-db"]
     },
     {
       "name": "shlink-db",

--- a/apps/shlink/docker-compose.json
+++ b/apps/shlink/docker-compose.json
@@ -1,0 +1,37 @@
+{
+  "services": [
+    {
+      "name": "shlink",
+      "image": "ghcr.io/shlinkio/shlink:4.4.0",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "DEFAULT_DOMAIN": "${APP_DOMAIN}",
+        "IS_HTTPS_ENABLED": "true",
+        "DB_DRIVER": "postgres",
+        "DB_HOST": "shlink-db",
+        "DB_NAME": "shlink",
+        "DB_USER": "shlink",
+        "DB_PASSWORD": "${SHLINK_POSTGRES_PASSWORD}"
+      },
+      "dependsOn": [
+        "shlink-db"
+      ]
+    },
+    {
+      "name": "shlink-db",
+      "image": "docker.io/library/postgres:17.2-alpine",
+      "environment": {
+        "POSTGRES_PASSWORD": "${SHLINK_POSTGRES_PASSWORD}",
+        "POSTGRES_USER": "shlink",
+        "POSTGRES_DB": "shlink"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for shlink
This is a shlink update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8207
  - [x] https://shlink.tipi.lan
##### In app tests :
  - [x] 📝 Create API key (from CLI)
  - [x] 🔗 Create short link (https://app.shlink.io/)
  - [x] 🔎 Access shortened link
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment