### PR TITLE
Dynamic compose/viewtube

### DIFF
--- a/apps/viewtube/config.json
+++ b/apps/viewtube/config.json
@@ -4,8 +4,9 @@
   "port": 8180,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "viewtube",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "0.17.0",
   "categories": ["media"],
   "description": "The open source, privacy-conscious way to enjoy your favorite YouTube content.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724767365000
+  "updated_at": 1735482522927
 }

--- a/apps/viewtube/docker-compose.json
+++ b/apps/viewtube/docker-compose.json
@@ -1,0 +1,46 @@
+{
+  "services": [
+    {
+      "name": "viewtube",
+      "image": "mauriceo/viewtube:0.17.0",
+      "isMain": true,
+      "internalPort": 8066,
+      "environment": {
+        "VIEWTUBE_DATABASE_HOST": "viewtube-mongodb",
+        "VIEWTUBE_REDIS_HOST": "viewtube-redis",
+        "VIEWTUBE_SECURE": "true",
+        "VIEWTUBE_CORS_ORIGIN": "${APP_PROTOCOL:-http}://${APP_DOMAIN}"
+      },
+      "dependsOn": [
+        "viewtube-mongodb",
+        "viewtube-redis"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/viewtube",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "viewtube-mongodb",
+      "image": "mongo:5",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/data/db"
+        }
+      ]
+    },
+    {
+      "name": "viewtube-redis",
+      "image": "redis:7",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/viewtube/docker-compose.json
+++ b/apps/viewtube/docker-compose.json
@@ -11,10 +11,7 @@
         "VIEWTUBE_SECURE": "true",
         "VIEWTUBE_CORS_ORIGIN": "${APP_PROTOCOL:-http}://${APP_DOMAIN}"
       },
-      "dependsOn": [
-        "viewtube-mongodb",
-        "viewtube-redis"
-      ],
+      "dependsOn": ["viewtube-mongodb", "viewtube-redis"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/viewtube",


### PR DESCRIPTION
## Dynamic compose for viewtube
This is a viewtube update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8180 (not meant to)
  - [x] https://viewtube.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🎬 Watch video (restricted by youtube)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/viewtube:/data
- [x] ${APP_DATA_DIR}/data/db:/data/db
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x] 🌳 Environment