### PR TITLE
Add dynamic compose for homebox

### DIFF
--- a/apps/homebox/config.json
+++ b/apps/homebox/config.json
@@ -4,8 +4,9 @@
   "port": 7745,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "homebox",
-  "tipi_version": 21,
+  "tipi_version": 22,
   "version": "0.16.0-rootless",
   "uid": 1000,
   "gid": 1000,
@@ -27,5 +28,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1732928541000
+  "updated_at": 1735482036499
 }

--- a/apps/homebox/docker-compose.json
+++ b/apps/homebox/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "services": [
+    {
+      "name": "homebox",
+      "image": "ghcr.io/sysadminsmedia/homebox:0.16.0-rootless",
+      "isMain": true,
+      "internalPort": 7745,
+      "user": "1000:1000",
+      "environment": {
+        "HBOX_LOG_LEVEL": "info",
+        "HBOX_LOG_FORMAT": "text",
+        "HBOX_WEB_MAX_UPLOAD_SIZE": "10",
+        "HBOX_OPTIONS_ALLOW_REGISTRATION": "${HBOX_OPTIONS_ALLOW_REGISTRATION}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/homebox-data",
+          "containerPath": "/data/"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for homebox
This is a homebox update for using dynamic compose. (no other change)
##### Situations tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:7745
  - [x] https://homebox.tipi.lan
  - [x] https://homebox.domain.com
##### In App tests :
  - [x] 📝 Register and create entries
  - [x] 🌆 Uploading data
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/homebox-data:/data/
##### Specific instructions verified :
- [x] 🌳 Environment (HBOX_LOG_LEVEL=info, HBOX_LOG_FORMAT=text, HBOX_WEB_MAX_UPLOAD_SIZE=10, HBOX_OPTIONS_ALLOW_REGISTRATION=${HBOX_OPTIONS_ALLOW_REGISTRATION})
- [x] 👤 User (1000:1000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic configuration in HomeBox application
  - Introduced new Docker Compose configuration for HomeBox service

- **Updates**
  - Upgraded Tipi framework version to 22
  - Updated HomeBox service to version 0.16.0-rootless
  - Configured logging and upload settings for the service

- **Configuration**
  - Added persistent data volume for HomeBox
  - Enabled configurable registration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->