### PR TITLE
Add dynamic compose for bazarr

### DIFF
--- a/apps/bazarr/config.json
+++ b/apps/bazarr/config.json
@@ -3,9 +3,10 @@
   "name": "Bazarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 6767,
   "id": "bazarr",
-  "tipi_version": 19,
+  "tipi_version": 20,
   "version": "1.5.1",
   "categories": ["media", "utilities"],
   "description": "Bazarr is a companion application to Sonarr and Radarr that manages and downloads subtitles based on your requirements.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735757678000
+  "updated_at": 1736281703975
 }

--- a/apps/bazarr/docker-compose.json
+++ b/apps/bazarr/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "bazarr",
+      "image": "lscr.io/linuxserver/bazarr:1.5.1",
+      "isMain": true,
+      "internalPort": 6767,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for bazarr
This is a bazarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:6767
  - [x] https://bazarr.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🎬 Downloading metadata
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ)
- 🌐 DNS (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated Bazarr configuration version to 20
	- Enabled dynamic configuration settings
	- Updated configuration timestamp

- **Service Deployment**
	- Added Docker Compose configuration for Bazarr service
	- Deployed Bazarr version 1.5.1
	- Configured volume mappings for data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->