### PR TITLE
Add dynamic compose for joplin

### DIFF
--- a/apps/joplin/config.json
+++ b/apps/joplin/config.json
@@ -3,9 +3,10 @@
   "name": "Joplin Server",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8099,
   "id": "joplin",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "3.0.1",
   "categories": ["utilities"],
   "description": "Default credentials: admin@localhost / admin",
@@ -24,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724015121000
+  "updated_at": 1736281869024
 }

--- a/apps/joplin/docker-compose.json
+++ b/apps/joplin/docker-compose.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "joplin",
+      "image": "florider89/joplin-server:3.0.1",
+      "isMain": true,
+      "internalPort": 22300,
+      "environment": {
+        "APP_PORT": "22300",
+        "APP_BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/",
+        "DB_CLIENT": "pg",
+        "POSTGRES_PASSWORD": "${JOPLIN_DB_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DATABASE": "joplin",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_HOST": "db-joplin",
+        "MAX_TIME_DRIFT": "0"
+      },
+      "dependsOn": [
+        "db-joplin"
+      ]
+    },
+    {
+      "name": "db-joplin",
+      "image": "postgres:14.2",
+      "environment": {
+        "POSTGRES_PASSWORD": "${JOPLIN_DB_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "joplin"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/joplin/docker-compose.json
+++ b/apps/joplin/docker-compose.json
@@ -17,9 +17,7 @@
         "POSTGRES_HOST": "db-joplin",
         "MAX_TIME_DRIFT": "0"
       },
-      "dependsOn": [
-        "db-joplin"
-      ]
+      "dependsOn": ["db-joplin"]
     },
     {
       "name": "db-joplin",


### PR DESCRIPTION
## Dynamic compose for joplin
This is a joplin update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8099
  - [x] https://joplin.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] ✍️ Write docs
  - [x] 🖼 Uploading photos
  - [x] 📱 Access through mobile app
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment- 
- 🌐 DNS (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Joplin Server
  - Updated Tipi framework version to 15

- **Chores**
  - Introduced Docker Compose configuration for Joplin application
  - Updated Joplin Server to version 3.0.1
  - Configured PostgreSQL database service for Joplin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->