### PR TITLE
Add dynamic compose for libreddit

### DIFF
--- a/apps/libreddit/config.json
+++ b/apps/libreddit/config.json
@@ -3,9 +3,10 @@
   "name": "LibReddit",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8105,
   "id": "libreddit",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "latest",
   "categories": ["social"],
   "description": "LibReddit is a bloat free reddit frontend written in Rust, no ads, no tracking and strong Content Security Policy prevents any request from going to reddit, everything is proxied.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736281890530
 }

--- a/apps/libreddit/docker-compose.json
+++ b/apps/libreddit/docker-compose.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "libreddit",
+      "image": "libreddit/libreddit:latest",
+      "isMain": true,
+      "internalPort": 8080
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for libreddit
This is a libreddit update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://libreddit.tipi.lan
##### In app tests :
  - [x] 🤓 Check r/runtipi
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
No volume
##### Specific instructions verified :
- 🌐 DNS (skipped)