### PR TITLE
Add dynamic compose for libretranslate

### DIFF
--- a/apps/libretranslate/config.json
+++ b/apps/libretranslate/config.json
@@ -3,9 +3,10 @@
   "name": "LibreTranslate",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8121,
   "id": "libretranslate",
-  "tipi_version": 21,
+  "tipi_version": 22,
   "version": "1.6.2",
   "categories": ["utilities"],
   "description": "Free and Open Source Machine Translation API, entirely self-hosted. Unlike other APIs, it doesn't rely on proprietary providers such as Google or Azure to perform translations. Instead, its translation engine is powered by the open source Argos Translate library.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730917217000
+  "updated_at": 1736281895107
 }

--- a/apps/libretranslate/docker-compose.json
+++ b/apps/libretranslate/docker-compose.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "libretranslate",
+      "image": "libretranslate/libretranslate:v1.6.2",
+      "isMain": true,
+      "internalPort": 5000
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for libretranslate
This is a libretranslate update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8121
  - [x] https://libretranslate.tipi.lan
##### In app tests :
  - [x] 📝 Translate a phrase
##### Specific instructions verified :
- 🌐 DNS (skipped)