### PR TITLE
Add dynamic compose for overseerr

### DIFF
--- a/apps/overseerr/config.json
+++ b/apps/overseerr/config.json
@@ -3,9 +3,10 @@
   "name": "Overseerr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8116,
   "id": "overseerr",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "1.33.2",
   "categories": ["media", "utilities"],
   "description": "Overseerr is a free and open source software application for managing requests for your media library. It integrates with your existing services, such as Sonarr, Radarr, and Plex!",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736282041603
 }

--- a/apps/overseerr/docker-compose.json
+++ b/apps/overseerr/docker-compose.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "overseerr",
+      "image": "ghcr.io/linuxserver/overseerr:1.33.2",
+      "isMain": true,
+      "internalPort": 5055,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for overseerr
This is a overseerr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://overseerr.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 🔧 Connect to Plex Server
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data/config:/config
##### Specific instructions verified :
- [x] 🌳 Environment
- 🌐 DNS (skipped)