### PR TITLE
Add dynamic compose for privatebin

### DIFF
--- a/apps/privatebin/config.json
+++ b/apps/privatebin/config.json
@@ -3,9 +3,10 @@
   "name": "PrivateBin",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8122,
   "id": "privatebin",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "1.7.5",
   "categories": ["utilities"],
   "description": "PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted and decrypted in the browser using 256bit AES in Galois Counter mode.",
@@ -17,5 +18,5 @@
   "gid": 82,
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731754550000
+  "updated_at": 1736282093497
 }

--- a/apps/privatebin/docker-compose.json
+++ b/apps/privatebin/docker-compose.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "privatebin",
+      "image": "privatebin/nginx-fpm-alpine:1.7.5",
+      "isMain": true,
+      "internalPort": 8080,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/srv/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for privatebin
This is a privatebin update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://privatebin.tipi.lan
##### In app tests :
  - [x] 📝 Create a note
  - [x] 🔗 Create and share a link
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/srv/data
##### Specific instructions verified :
- 🌐 DNS (skipped)