### PR TITLE
Add dynamic compose for radarr

### DIFF
--- a/apps/radarr/config.json
+++ b/apps/radarr/config.json
@@ -3,9 +3,10 @@
   "name": "Radarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8088,
   "id": "radarr",
-  "tipi_version": 26,
+  "tipi_version": 27,
   "version": "5.17.2",
   "categories": ["media", "utilities"],
   "description": "Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736092304000
+  "updated_at": 1736282111297
 }

--- a/apps/radarr/docker-compose.json
+++ b/apps/radarr/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "radarr",
+      "image": "ghcr.io/linuxserver/radarr:5.17.2",
+      "isMain": true,
+      "internalPort": 7878,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for radarr
This is a radarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://radarr.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🎬 Downloading metadata
  - [x] 🌊 Check after a full download (can't test on my side)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PUID, PGID, TZ)
- 🌐 DNS (skipped)