### PR TITLE
Add dynamic compose for readarr

### DIFF
--- a/apps/readarr/config.json
+++ b/apps/readarr/config.json
@@ -3,9 +3,10 @@
   "name": "Readarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8112,
   "id": "readarr",
-  "tipi_version": 32,
+  "tipi_version": 33,
   "version": "0.4.8-nightly",
   "categories": ["books", "media"],
   "description": "",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736087016000
+  "updated_at": 1736282120014
 }

--- a/apps/readarr/docker-compose.json
+++ b/apps/readarr/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "readarr",
+      "image": "lscr.io/linuxserver/readarr:0.4.8-nightly",
+      "isMain": true,
+      "internalPort": 8787,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for readarr
This is a readarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:
  - [x] https://readarr.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 📚 Downloading metadata
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ)
- 🌐 DNS (skipped)