### PR TITLE
Add dynamic compose for send

### DIFF
--- a/apps/send/config.json
+++ b/apps/send/config.json
@@ -3,9 +3,10 @@
   "name": "Send",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8126,
   "id": "send",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "latest",
   "categories": ["utilities"],
   "description": "A file sharing experiment which allows you to send encrypted files to other users.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736282162483
 }

--- a/apps/send/docker-compose.json
+++ b/apps/send/docker-compose.json
@@ -13,9 +13,7 @@
         "MAX_FILE_SIZE": "2147483648",
         "FILE_DIR": "/uploads"
       },
-      "dependsOn": [
-        "send-redis"
-      ],
+      "dependsOn": ["send-redis"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/uploads",

--- a/apps/send/docker-compose.json
+++ b/apps/send/docker-compose.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "send",
+      "image": "registry.gitlab.com/timvisee/send:latest",
+      "isMain": true,
+      "internalPort": 1443,
+      "environment": {
+        "NODE_ENV": "production",
+        "BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "REDIS_HOST": "send-redis",
+        "MAX_FILE_SIZE": "2147483648",
+        "FILE_DIR": "/uploads"
+      },
+      "dependsOn": [
+        "send-redis"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uploads",
+          "containerPath": "/uploads"
+        }
+      ]
+    },
+    {
+      "name": "send-redis",
+      "image": "redis:alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "5s",
+        "timeout": "3s",
+        "retries": 30,
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for send
This is a send update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://send.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 🌆 Uploading data
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/uploads:/uploads
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck
- 🌐 DNS (skipped)