### PR TITLE
Add dynamic compose for sonarr

### DIFF
--- a/apps/sonarr/config.json
+++ b/apps/sonarr/config.json
@@ -3,9 +3,10 @@
   "name": "Sonarr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8098,
   "id": "sonarr",
-  "tipi_version": 18,
+  "tipi_version": 19,
   "version": "4.0.12",
   "categories": ["media", "utilities"],
   "description": "Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736136539000
+  "updated_at": 1736282187066
 }

--- a/apps/sonarr/docker-compose.json
+++ b/apps/sonarr/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "sonarr",
+      "image": "lscr.io/linuxserver/sonarr:4.0.12",
+      "isMain": true,
+      "internalPort": 8989,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
 ## Dynamic compose for sonarr
This is a sonarr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://sonarr.tipi.lan
##### In app tests :
  - [x] 📝 Register and create entries
  - [x] 📺 Downloading metadata
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ)
- 🌐 DNS (skipped)