### PR TITLE
Add dynamic compose for uptime-kuma

### DIFF
--- a/apps/uptime-kuma/config.json
+++ b/apps/uptime-kuma/config.json
@@ -3,9 +3,10 @@
   "name": "Uptime Kuma",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8125,
   "id": "uptime-kuma",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "1",
   "categories": ["utilities"],
   "description": "It is a self-hosted monitoring tool like Uptime Robot.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736282249014
 }

--- a/apps/uptime-kuma/docker-compose.json
+++ b/apps/uptime-kuma/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "uptime-kuma",
+      "image": "louislam/uptime-kuma:1",
+      "isMain": true,
+      "internalPort": 3001,
+      "volumes": [
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/app/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for uptime-kuma
This is a uptime-kuma update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://uptime-kuma.tipi.lan
##### In app tests :
- [x] 📝 Register and create entries
- [x] 🐳 Add probes for containers
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /var/run/docker.sock:/var/run/docker.sock
- [x] ${APP_DATA_DIR}/data:/app/data
##### Specific instructions verified :
- 🌐 DNS (skipped)