### PR TITLE
Add dynamic compose for whisparr

### DIFF
--- a/apps/whisparr/config.json
+++ b/apps/whisparr/config.json
@@ -3,9 +3,10 @@
   "name": "Whisparr",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 6969,
   "id": "whisparr",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "nightly-2.0.0.548",
   "categories": ["media", "utilities"],
   "description": "Whisparr is an adult movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.",
@@ -37,5 +38,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736282257561
 }

--- a/apps/whisparr/docker-compose.json
+++ b/apps/whisparr/docker-compose.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "whisparr",
+      "image": "ghcr.io/hotio/whisparr:nightly-2.0.0.548",
+      "isMain": true,
+      "internalPort": 6969,
+      "hostname": "${APP_ID}",
+      "environment": {
+        "PUID": "${WHISPARR_PUID-1000}",
+        "PGID": "${WHISPARR_PGID-1000}",
+        "UMASK": "${WHISPARR_UMASK-002}",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/etc/timezone",
+          "containerPath": "/etc/timezone",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/6969' || exit 1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for whisparr
This is a whisparr update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:6969
  - [x] https://whisparr.tipi.lan
##### In app tests :
- [x] 📝 Register and add index, download client etc...
- [x] 🔞 Downloading for a friend
- [x] 🌊 Check after a full download
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /etc/localtime:/etc/localtime:ro
- [x] /etc/timezone:/etc/timezone:ro
- [x] ${APP_DATA_DIR}/data:/config
- [x] ${ROOT_FOLDER_HOST}/media:/media
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck
- [x] 🌐 Hostname
- 🌐 DNS (skipped)