### PR TITLE
Add dynamic compose for dashdot

### DIFF
--- a/apps/dashdot/config.json
+++ b/apps/dashdot/config.json
@@ -4,8 +4,9 @@
   "port": 8173,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "dashdot",
-  "tipi_version": 19,
+  "tipi_version": 20,
   "version": "5.9.0",
   "categories": ["utilities"],
   "description": "dash. (or dashdot) is a modern server dashboard, running on the latest tech, designed with glassmorphism in mind. It is intended to be used for smaller VPS and private servers.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1727892200000
+  "updated_at": 1736281740498
 }

--- a/apps/dashdot/docker-compose.json
+++ b/apps/dashdot/docker-compose.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "dashdot",
+      "image": "mauricenino/dashdot:5.9.0",
+      "isMain": true,
+      "internalPort": 3001,
+      "environment": {
+        "DASHDOT_SHOW_HOST": "false",
+        "DASHDOT_SHOW_DASH_VERSION": "true",
+        "DASHDOT_ENABLE_CPU_TEMPS": "true",
+        "DASHDOT_USE_IMPERIAL": "true",
+        "DASHDOT_ALWAYS_SHOW_PERCENTAGES": "true",
+        "DASHDOT_PAGE_TITLE": "dashdot",
+        "DASHDOT_ACCEPT_OOKLA_EULA": "true"
+      },
+      "volumes": [
+        {
+          "hostPath": "/",
+          "containerPath": "/mnt/host",
+          "readOnly": true
+        }
+      ],
+      "privileged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for dashdot
This is a dashdot update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8173
  - [x] https://dashdot.tipi.lan
##### In app tests :
  - [x] 📊 Check metrics
##### Volumes mapping verified :
- [x] /:/mnt/host:ro
##### Specific instructions verified :
- [x] 🌳 Environment (too much to list)
- [x] 👑 Privileged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration option for Dash application
  - Updated Dash application to version 20

- **Configuration Changes**
  - Modified Docker Compose configuration for Dashdot service
  - Updated service to use Docker image version 5.9.0
  - Configured new environment variables and volume mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->