### PR TITLE
Add dynamic compose for onedev

### DIFF
--- a/apps/onedev/config.json
+++ b/apps/onedev/config.json
@@ -4,8 +4,9 @@
   "port": 6610,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "onedev",
-  "tipi_version": 136,
+  "tipi_version": 137,
   "version": "11.6.9",
   "categories": ["development"],
   "description": "Self-hosted Git Server with Kanban and CI/CD",
@@ -46,5 +47,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735454987000
+  "updated_at": 1736282025318
 }

--- a/apps/onedev/docker-compose.json
+++ b/apps/onedev/docker-compose.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "onedev",
+      "image": "1dev/server:11.6.9",
+      "isMain": true,
+      "internalPort": 6610,
+      "addPorts": [
+        {
+          "hostPort": 6611,
+          "containerPort": 6611
+        }
+      ],
+      "environment": {
+        "hibernate_dialect": "io.onedev.server.persistence.PostgreSQLDialect",
+        "hibernate_connection_driver_class": "org.postgresql.Driver",
+        "hibernate_connection_url": "jdbc:postgresql://onedev-db:5432/onedev",
+        "hibernate_connection_username": "tipi",
+        "hibernate_connection_password": "${ONEDEV_DB_PASSWORD}",
+        "initial_user": "${ONEDEV_USERNAME}",
+        "initial_password": "${ONEDEV_PASSWORD}",
+        "initial_email": "${ONEDEV_EMAIL}",
+        "initial_server_url": "${APP_DOMAIN}"
+      },
+      "dependsOn": [
+        "onedev-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/onedev",
+          "containerPath": "/opt/onedev"
+        },
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock"
+        }
+      ]
+    },
+    {
+      "name": "onedev-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${ONEDEV_DB_PASSWORD}",
+        "POSTGRES_DB": "onedev"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/onedev/docker-compose.json
+++ b/apps/onedev/docker-compose.json
@@ -23,9 +23,7 @@
         "initial_email": "${ONEDEV_EMAIL}",
         "initial_server_url": "${APP_DOMAIN}"
       },
-      "dependsOn": [
-        "onedev-db"
-      ],
+      "dependsOn": ["onedev-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/onedev",


### PR DESCRIPTION
## Dynamic compose for onedev
This is a onedev update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:6610
  - [x] https://onedev.tipi.lan
- [x] Additionnals ports are mapped correctly (6611)
##### In app tests :
  - [x] 📝 Register and log in
  - [x] ⌨ Create repository
  - [x] 🐚 Access git repository through SSH
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/onedev:/opt/onedev
- [x] /var/run/docker.sock:/var/run/docker.sock
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment