### PR TITLE
Add dynamic compose for siyuan

### DIFF
--- a/apps/siyuan/config.json
+++ b/apps/siyuan/config.json
@@ -8,11 +8,12 @@
   "port": 6806,
   "categories": ["utilities"],
   "description": "SiYuan is a privacy-first personal knowledge management system, support fine-grained block-level reference and Markdown WYSIWYG.",
-  "tipi_version": 15,
+  "tipi_version": 16,
   "version": "3.1.14",
   "website": "https://b3log.org/siyuan/en/",
   "source": "https://github.com/siyuan-note/siyuan",
   "exposable": true,
+  "dynamic_config": true,
   "supported_architectures": ["arm64", "amd64"],
   "form_fields": [
     {
@@ -28,5 +29,5 @@
   "uid": 1000,
   "gid": 1000,
   "created_at": 1691943801422,
-  "updated_at": 1733204273000
+  "updated_at": 1736282174890
 }

--- a/apps/siyuan/docker-compose.json
+++ b/apps/siyuan/docker-compose.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "siyuan",
+      "image": "b3log/siyuan:v3.1.14",
+      "isMain": true,
+      "internalPort": 6806,
+      "user": "1000:1000",
+      "environment": {
+        "TZ": "${TZ}",
+        "PUID": "1000",
+        "PGID": "1000"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/workspace",
+          "containerPath": "/siyuan/workspace/"
+        }
+      ],
+      "command": [
+        "--workspace=/siyuan/workspace/",
+        "--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}"
+      ]
+    }
+  ]
+}

--- a/apps/siyuan/docker-compose.json
+++ b/apps/siyuan/docker-compose.json
@@ -18,10 +18,7 @@
           "containerPath": "/siyuan/workspace/"
         }
       ],
-      "command": [
-        "--workspace=/siyuan/workspace/",
-        "--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}"
-      ]
+      "command": ["--workspace=/siyuan/workspace/", "--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}"]
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for siyuan
This is a siyuan update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://localdomain.tld
##### In app tests :
  - [x] 📝 Create some notes
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/workspace:/siyuan/workspace/
##### Specific instructions verified :
- [x] 🌳 Environment (TZ, PUID,PGID)
- [x] 💻 command
- [x] 👤 User (1000:1000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration support for the SiYuan application
	- Introduced Docker Compose configuration for simplified deployment

- **Chores**
	- Updated application version from 15 to 16
	- Updated application timestamp

- **Infrastructure**
	- Added Docker Compose service configuration with configurable environment variables
	- Set up container with specific image, port, and volume mounting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->