### PR TITLE
Add dynamic compose for cheshire-cat-ai

### DIFF
--- a/apps/cheshire-cat-ai/config.json
+++ b/apps/cheshire-cat-ai/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 1865,
   "exposable": true,
+  "dynamic_config": true,
   "id": "cheshire-cat-ai",
   "description": "The Cheshire Cat is an open-source, hackable and production-ready framework that allows developing intelligent personal AI assistant agents on top of Large Language Models (LLM).",
-  "tipi_version": 6,
+  "tipi_version": 7,
   "version": "1.7.1",
   "categories": ["ai"],
   "short_desc": "A production-ready AI framework to develop AI agents.",
@@ -16,6 +17,6 @@
   "url_suffix": "/admin",
   "supported_architectures": ["amd64", "arm64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000,
+  "updated_at": 1736342391270,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/cheshire-cat-ai/docker-compose.json
+++ b/apps/cheshire-cat-ai/docker-compose.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "cheshire-cat-ai",
+      "image": "ghcr.io/cheshire-cat-ai/core:1.7.1",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "PYTHONUNBUFFERED": "1",
+        "WATCHFILES_FORCE_POLLING": "true"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/static",
+          "containerPath": "/app/cat/static"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/plugins",
+          "containerPath": "/app/cat/plugins"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/data",
+          "containerPath": "/app/cat/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for cheshire-cat-ai
This is a cheshire-cat-ai update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:1865
  - [ ] https://cheshire-cat-ai.tipi.lan (unchanged)
##### In app tests :
  - [x] 📝 Log in
  - [x] 🧠 Add AI provider
  - [x] 🛠 Add plugins
  - [x] 💬 Chat with LLM (only through exposed domain)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/static:/app/cat/static
- [x] ${APP_DATA_DIR}/data/plugins:/app/cat/plugins
- [x] ${APP_DATA_DIR}/data/data:/app/cat/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Enabled dynamic configuration for Cheshire Cat AI
	- Updated Tipi version to 7
	- Updated configuration timestamp

- **Docker Configuration**
	- Added Docker Compose configuration for Cheshire Cat AI service
	- Specified Docker image version 1.7.1
	- Configured volume mappings for data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->