### PR TITLE
Dynamic compose/filestash

### DIFF
--- a/apps/filestash/config.json
+++ b/apps/filestash/config.json
@@ -4,8 +4,9 @@
   "port": 8189,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "filestash",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "latest",
   "categories": ["utilities"],
   "description": "A modern web client for SFTP, S3, FTP, WebDAV, Git, Minio, LDAP, CalDAV, CardDAV, Mysql, Backblaze",
@@ -34,5 +35,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736342439770
 }

--- a/apps/filestash/docker-compose.json
+++ b/apps/filestash/docker-compose.json
@@ -13,9 +13,7 @@
         "DROPBOX_CLIENT_ID": "${FILESTASH_DROPBOX_CLIENT_ID}",
         "ONLYOFFICE_URL": "http://filestash-onlyoffice"
       },
-      "dependsOn": [
-        "filestash-onlyoffice"
-      ],
+      "dependsOn": ["filestash-onlyoffice"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",
@@ -26,9 +24,7 @@
     {
       "name": "filestash-onlyoffice",
       "image": "onlyoffice/documentserver:7.3.3.50",
-      "securityOpt": [
-        "seccomp:unconfined"
-      ]
+      "securityOpt": ["seccomp:unconfined"]
     }
   ]
 }

--- a/apps/filestash/docker-compose.json
+++ b/apps/filestash/docker-compose.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "filestash",
+      "image": "machines/filestash:latest",
+      "isMain": true,
+      "internalPort": 8334,
+      "environment": {
+        "APPLICATION_URL": "${APP_DOMAIN}",
+        "GDRIVE_CLIENT_ID": "${FILESTASH_GDRIVE_CLIENT_ID}",
+        "GDRIVE_CLIENT_SECRET": "${FILESTASH_GDRIVE_CLIENT_SECRET}",
+        "DROPBOX_CLIENT_ID": "${FILESTASH_DROPBOX_CLIENT_ID}",
+        "ONLYOFFICE_URL": "http://filestash-onlyoffice"
+      },
+      "dependsOn": [
+        "filestash-onlyoffice"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/app/data/state/"
+        }
+      ]
+    },
+    {
+      "name": "filestash-onlyoffice",
+      "image": "onlyoffice/documentserver:7.3.3.50",
+      "securityOpt": [
+        "seccomp:unconfined"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for filestash
This is a filestash update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8189
  - [x] https://filestash.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🌆 Try accessing data
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/app/data/state/
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🔒 Security Opt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added support for dynamic configuration
	- Updated Tipi version to 5
	- Updated configuration timestamp

- **Infrastructure**
	- Introduced Docker Compose configuration for Filestash application
	- Added services for Filestash and OnlyOffice document server
	- Configured environment variables and volume mounting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->