### PR TITLE
Add dynamic compose for guacamole

### DIFF
--- a/apps/guacamole/config.json
+++ b/apps/guacamole/config.json
@@ -9,11 +9,12 @@
   "url_suffix": "/guacamole",
   "categories": ["utilities"],
   "description": "Apache Guacamole is a clientless remote desktop gateway. It supports standard protocols like VNC, RDP, and SSH",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "1.5.5",
   "source": "https://github.com/apache/guacamole-server",
   "website": "https://guacamole.apache.org",
   "exposable": true,
+  "dynamic_config": true,
   "supported_architectures": ["amd64"],
   "form_fields": [
     {
@@ -24,5 +25,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736342477788
 }

--- a/apps/guacamole/docker-compose.json
+++ b/apps/guacamole/docker-compose.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "guacamole",
+      "image": "guacamole/guacamole:1.5.5",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "POSTGRESQL_DATABASE": "guacamole",
+        "POSTGRESQL_USER": "guacamole",
+        "POSTGRESQL_PASSWORD": "${GUACAMOLE_DB_PASSWORD}",
+        "GUACD_HOSTNAME": "guacamole-guacd",
+        "POSTGRESQL_HOSTNAME": "guacamole-db"
+      }
+    },
+    {
+      "name": "guacamole-guacd",
+      "image": "guacamole/guacd:1.5.5"
+    },
+    {
+      "name": "guacamole-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_DB": "guacamole",
+        "POSTGRES_USER": "guacamole",
+        "POSTGRES_PASSWORD": "${GUACAMOLE_DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/init/sql",
+          "containerPath": "/config/sql"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/init/init-guacamole.sh",
+          "containerPath": "/docker-entrypoint-initdb.d/init-guacamole.sh"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for guacamole
This is a guacamole update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8854
  - [x] https://guacamole.tipi.lan
##### In app tests :
  - [x] 📝 Register and log in
  - [x] 🌐 Add remote access to another host (SSH)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/init/sql:/config/sql
- [x] ${APP_DATA_DIR}/data/init/init-guacamole.sh:/docker-entrypoint-initdb.d/init-guacamole.sh
##### Specific instructions verified :
- [x] 🌳 Environment (POSTGRESQL_DATABASE, POSTGRESQL_USER, POSTGRESQL_PASSWORD, GUACD_HOSTNAME, POSTGRESQL_HOSTNAME, POSTGRES_DB POSTGRES_USER, POSTGRES_PASSWORD)