### PR TITLE
Add ynamic compose for hedgedoc

### DIFF
--- a/apps/hedgedoc/config.json
+++ b/apps/hedgedoc/config.json
@@ -4,8 +4,9 @@
   "port": 8142,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "hedgedoc",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "1.10.0",
   "categories": ["media"],
   "description": "HedgeDoc (formerly known as CodiMD) is an open-source, web-based, self-hosted, collaborative markdown editor. You can use it to easily collaborate on notes, graphs and even presentations in real-time. All you need to do is to share your note-link to your co-workers and they’re ready to go.",
@@ -31,5 +32,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1725294593000
+  "updated_at": 1736342481350
 }

--- a/apps/hedgedoc/docker-compose.json
+++ b/apps/hedgedoc/docker-compose.json
@@ -11,9 +11,7 @@
         "CMD_DOMAIN": "${APP_DOMAIN}",
         "CMD_URL_ADDPORT": "${HEDGEDOC_ADDPORT}"
       },
-      "dependsOn": [
-        "hedgedoc-db"
-      ],
+      "dependsOn": ["hedgedoc-db"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/hedgedoc-uploads",

--- a/apps/hedgedoc/docker-compose.json
+++ b/apps/hedgedoc/docker-compose.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "hedgedoc",
+      "image": "quay.io/hedgedoc/hedgedoc:1.10.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "CMD_DB_URL": "postgres://hedgedoc:${HEDGEDOC_DB_PASSWORD}@hedgedoc-db:5432/hedgedoc",
+        "CMD_DOMAIN": "${APP_DOMAIN}",
+        "CMD_URL_ADDPORT": "${HEDGEDOC_ADDPORT}"
+      },
+      "dependsOn": [
+        "hedgedoc-db"
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/hedgedoc-uploads",
+          "containerPath": "/hedgedoc/public/uploads"
+        }
+      ]
+    },
+    {
+      "name": "hedgedoc-db",
+      "image": "postgres:13.4-alpine",
+      "environment": {
+        "POSTGRES_USER": "hedgedoc",
+        "POSTGRES_PASSWORD": "${HEDGEDOC_DB_PASSWORD}",
+        "POSTGRES_DB": "hedgedoc"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for hedgedoc
This is a hedgedoc update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8142
  - [x] https://hedgedoc.tipi.lan
##### In app tests :
  - [x] 📝 Register
  - [x] 📜 Write note
  - [x] 🌆 Upload images
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/hedgedoc-uploads:/hedgedoc/public/uploads
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment (CMD_DB_URL, CMD_DOMAIN, CMD_URL_ADDPORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in HedgeDoc
	- Introduced a new Docker Compose configuration for HedgeDoc

- **Chores**
	- Updated application version
	- Updated configuration timestamp

- **Infrastructure**
	- Set up PostgreSQL database service for HedgeDoc
	- Configured HedgeDoc service with specific image and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->