### PR TITLE
Add dynamic compose for openbooks

### DIFF
--- a/apps/openbooks/config.json
+++ b/apps/openbooks/config.json
@@ -4,8 +4,9 @@
   "port": 8152,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "openbooks",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "url_suffix": "/openbooks/",
   "version": "4.5.0",
   "categories": ["media", "books"],
@@ -27,5 +28,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736342618332
 }

--- a/apps/openbooks/docker-compose.json
+++ b/apps/openbooks/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "openbooks",
+      "image": "evanbuss/openbooks:4.5.0",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "BASE_PATH": "/openbooks/"
+      },
+      "volumes": [
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/books/",
+          "containerPath": "/books"
+        }
+      ],
+      "command": "./openbooks server --dir /books --port 80 --persist --name ${OPENBOOKS_IRC_USERNAME}"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for openbooks
This is a openbooks update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8152
  - [ ] https://openbooks.tipi.lan (unchanged)
##### In app tests :
  - [x] 📝 Register
  - [x] 🌆 Search book
  - [x] 🌊 Check after a full download
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${ROOT_FOLDER_HOST}/media/data/books/:/books
##### Specific instructions verified :
- [x] 🌳 Environment (BASE_PATH)