### PR TITLE
Add dynamic compose for plex

### DIFF
--- a/apps/plex/config.json
+++ b/apps/plex/config.json
@@ -3,9 +3,10 @@
   "name": "Plex",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 32400,
   "id": "plex",
-  "tipi_version": 33,
+  "tipi_version": 34,
   "version": "1.41.3",
   "url_suffix": "/web",
   "categories": ["media"],
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733939771000
+  "updated_at": 1736342652047
 }

--- a/apps/plex/docker-compose.json
+++ b/apps/plex/docker-compose.json
@@ -5,6 +5,7 @@
       "name": "plex",
       "image": "lscr.io/linuxserver/plex:1.41.3",
       "isMain": true,
+      "internalPort": 32400,
       "networkMode": "host",
       "environment": {
         "PUID": "1000",

--- a/apps/plex/docker-compose.json
+++ b/apps/plex/docker-compose.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "plex",
+      "image": "lscr.io/linuxserver/plex:1.41.3",
+      "isMain": true,
+      "networkMode": "host",
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "VERSION": "docker",
+        "ADVERTISE_IP": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/transcode",
+          "containerPath": "/transcode"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data",
+          "containerPath": "/media"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for plex
This is a plex update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [ ] https://plex.tipi.lan (unchanged)
##### In app tests :
  - [x] 📝 Register
  - [x] 🌆 Scanning data for videos & music
  - [x] 🍿 Watch movie
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/transcode:/transcode
- [x] ${ROOT_FOLDER_HOST}/media/data:/media
##### Specific instructions verified :
- [x] 🌳 Environment (PGID,PUID,VERSION,ADVERTISE_IP)