### PR TITLE
Add dynamic compose for drawio

### DIFF
--- a/apps/drawio/config.json
+++ b/apps/drawio/config.json
@@ -3,10 +3,11 @@
   "available": true,
   "port": 8734,
   "exposable": true,
+  "dynamic_config": true,
   "url_suffix": "?offline=1",
   "id": "drawio",
   "description": "draw.io is a JavaScript, client-side editor for general diagramming and whiteboarding.",
-  "tipi_version": 60,
+  "tipi_version": 61,
   "version": "24.7.17",
   "categories": ["utilities"],
   "short_desc": "Diagramming and whiteboarding app.",
@@ -16,6 +17,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1727806670000,
+  "updated_at": 1736624564906,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/drawio/docker-compose.json
+++ b/apps/drawio/docker-compose.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "drawio",
+      "image": "jgraph/drawio:24.7.17",
+      "isMain": true,
+      "internalPort": 8080,
+      "tty": true,
+      "stdinOpen": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for drawio
This is a drawio update for using dynamic compose.
#### Reaching the app :
- [x]  [http://localip:port](http://localip:port)
- [x]  [https://drawio.tipi.local](https://drawio.tipi.local)
#### In app tests :
- [x] 📝 Draw
  - [x] ⬆️ Import/export
#### Volumes mapping verified :
All data is on client
#### Specific instructions :
- [x]  🔤 TTY (True)
- [x]  🤖 Stdin open