### PR TITLE
Add dynamic compose for nocodb

### DIFF
--- a/apps/nocodb/config.json
+++ b/apps/nocodb/config.json
@@ -4,8 +4,9 @@
   "port": 8146,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "nocodb",
-  "tipi_version": 68,
+  "tipi_version": 69,
   "version": "0.260.1",
   "categories": ["utilities"],
   "description": "The Open Source Airtable Alternative. Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadsheet.",
@@ -41,5 +42,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736523638000
+  "updated_at": 1736624756502
 }

--- a/apps/nocodb/docker-compose.json
+++ b/apps/nocodb/docker-compose.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "nocodb",
+      "image": "nocodb/nocodb:0.260.1",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "NC_DB": "pg://nocodb-db:5432?u",
+        "NC_PUBLIC_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "NC_AUTH_JWT_SECRET": "${NOCODB_JWT_SECRET}",
+        "NC_REDIS_URL": "redis://default:${NOCODB_REDIS_PASSWORD}@nocodb-redis:6379",
+        "DB_QUERY_LIMIT_DEFAULT": "${NOCODB_TABLE_ROWS-25}"
+      },
+      "dependsOn": {
+        "nocodb-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nocode-data",
+          "containerPath": "/usr/app/data"
+        }
+      ]
+    },
+    {
+      "name": "nocodb-db",
+      "image": "postgres:16",
+      "environment": {
+        "POSTGRES_DB": "nocodb",
+        "POSTGRES_PASSWORD": "${NOCODB_DB_PASSWORD}",
+        "POSTGRES_USER": "postgres"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "2s",
+        "retries": 10,
+        "test": "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""
+      }
+    },
+    {
+      "name": "nocodb-redis",
+      "image": "redis:alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "redis-server --requirepass ${NOCODB_REDIS_PASSWORD}",
+      "healthCheck": {
+        "interval": "1s",
+        "timeout": "3s",
+        "retries": 30,
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}

--- a/apps/nocodb/docker-compose.json
+++ b/apps/nocodb/docker-compose.json
@@ -7,7 +7,7 @@
       "isMain": true,
       "internalPort": 8080,
       "environment": {
-        "NC_DB": "pg://nocodb-db:5432?u",
+        "NC_DB": "pg://nocodb-db:5432?u=postgres&p=${NOCODB_DB_PASSWORD}&d=nocodb",
         "NC_PUBLIC_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
         "NC_AUTH_JWT_SECRET": "${NOCODB_JWT_SECRET}",
         "NC_REDIS_URL": "redis://default:${NOCODB_REDIS_PASSWORD}@nocodb-redis:6379",


### PR DESCRIPTION
## Dynamic compose for nocodb
This is a nocodb update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://nocodb.tipi.local
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🗄 Connect to another docker database
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/nocode-data:/usr/app/data
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🩺 Healthcheck
- [x] ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Enabled dynamic configuration
	- Updated Tipi version to 69
	- Modified configuration timestamp

- **Infrastructure**
	- Added Docker Compose configuration for NocoDB
	- Introduced services for NocoDB, PostgreSQL database, and Redis
	- Configured service dependencies and health checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->