### PR TITLE
Add dynamic compose for portainer

### DIFF
--- a/apps/portainer/config.json
+++ b/apps/portainer/config.json
@@ -4,9 +4,10 @@
   "port": 9443,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "https": true,
   "id": "portainer",
-  "tipi_version": 32,
+  "tipi_version": 33,
   "version": "2.25.1-alpine",
   "categories": ["utilities"],
   "description": "Portainer Community Edition is a lightweight service delivery platform for containerized applications that can be used to manage Docker, Swarm, Kubernetes and ACI environments.",
@@ -17,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734654814000
+  "updated_at": 1736624818466
 }

--- a/apps/portainer/docker-compose.json
+++ b/apps/portainer/docker-compose.json
@@ -5,7 +5,7 @@
       "name": "portainer",
       "image": "portainer/portainer-ce:2.25.1-alpine",
       "isMain": true,
-      "internalPort": 9443,
+      "internalPort": 9000,
       "volumes": [
         {
           "hostPath": "/var/run/docker.sock",

--- a/apps/portainer/docker-compose.json
+++ b/apps/portainer/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "portainer",
+      "image": "portainer/portainer-ce:2.25.1-alpine",
+      "isMain": true,
+      "internalPort": 9443,
+      "volumes": [
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for portainer
This is a portainer update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://portainer.tipi.lan
##### In app tests :
  - [x] 📝 Register and login
  - [x] 🐳 Interact with containers (start, stop, create, delete)
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] /var/run/docker.sock:/var/run/docker.sock
- [x] ${APP_DATA_DIR}/data:/data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration support for Portainer
	- Updated Portainer version to 2.25.1
	- Configured Docker Compose service for Portainer with persistent data storage

- **Chores**
	- Updated Tipi version from 32 to 33

<!-- end of auto-generated comment: release notes by coderabbit.ai -->