### PR TITLE
Add dynamic compose for photoprism

### DIFF
--- a/apps/photoprism/config.json
+++ b/apps/photoprism/config.json
@@ -4,8 +4,9 @@
   "port": 8110,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "photoprism",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "240420",
   "categories": ["photography"],
   "description": "PhotoPrism® is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way. You can run it at home, on a private server, or in the cloud. Default username: admin",
@@ -34,5 +35,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736624799405
 }

--- a/apps/photoprism/docker-compose.json
+++ b/apps/photoprism/docker-compose.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "photoprism",
+      "image": "photoprism/photoprism:240420",
+      "isMain": true,
+      "internalPort": 2342,
+      "environment": {
+        "PHOTOPRISM_ADMIN_PASSWORD": "${PHOTOPRISM_ADMIN_PASSWORD}",
+        "PHOTOPRISM_SITE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/",
+        "PHOTOPRISM_ORIGINALS_LIMIT": 5000,
+        "PHOTOPRISM_HTTP_COMPRESSION": "gzip",
+        "PHOTOPRISM_LOG_LEVEL": "info",
+        "PHOTOPRISM_PUBLIC": "false",
+        "PHOTOPRISM_READONLY": "false",
+        "PHOTOPRISM_EXPERIMENTAL": "false",
+        "PHOTOPRISM_DISABLE_CHOWN": "false",
+        "PHOTOPRISM_DISABLE_WEBDAV": "false",
+        "PHOTOPRISM_DISABLE_SETTINGS": "false",
+        "PHOTOPRISM_DISABLE_TENSORFLOW": "false",
+        "PHOTOPRISM_DISABLE_FACES": "false",
+        "PHOTOPRISM_DISABLE_CLASSIFICATION": "false",
+        "PHOTOPRISM_DISABLE_RAW": "false",
+        "PHOTOPRISM_RAW_PRESETS": "false",
+        "PHOTOPRISM_JPEG_QUALITY": 85,
+        "PHOTOPRISM_DETECT_NSFW": "false",
+        "PHOTOPRISM_UPLOAD_NSFW": "true",
+        "PHOTOPRISM_DATABASE_DRIVER": "mysql",
+        "PHOTOPRISM_DATABASE_SERVER": "photoprism-db:3306",
+        "PHOTOPRISM_DATABASE_NAME": "photoprism",
+        "PHOTOPRISM_DATABASE_USER": "photoprism",
+        "PHOTOPRISM_DATABASE_PASSWORD": "${DB_PASSWORD}",
+        "PHOTOPRISM_SITE_CAPTION": "AI-Powered Photos App"
+      },
+      "dependsOn": ["photoprism-db"],
+      "volumes": [
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/images",
+          "containerPath": "/photoprism/originals"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/photoprism/storage",
+          "containerPath": "/photoprism/storage"
+        }
+      ],
+      "workingDir": "/photoprism"
+    },
+    {
+      "name": "photoprism-db",
+      "image": "mariadb:10.8",
+      "environment": {
+        "MARIADB_DATABASE": "photoprism",
+        "MARIADB_USER": "photoprism",
+        "MARIADB_PASSWORD": "${DB_PASSWORD}",
+        "MARIADB_ROOT_PASSWORD": "${DB_ROOT_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mariadb",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "command": "mysqld --innodb-buffer-pool-size=128M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for photoprism
This is a photoprism update for using dynamic compose.
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://photoprism.tipi.lan
##### In app tests :
- [x]  📝 Register and log in
- [x]  🖱 Basic interaction
- [x]  🌆 Uploading photo
- [x] 😀 Check face recognition
- [x]  🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${ROOT_FOLDER_HOST}/media/data/images:/photoprism/originals
- [x] ${APP_DATA_DIR}/data/photoprism/storage:/photoprism/storage
- [x] ${APP_DATA_DIR}/data/mariadb:/var/lib/mysql
##### Specific instructions verified :
- [x] 🌳 Environment
- [x]  🔗 Depends on
- [x]  📂 Working dir (/photoprism)
- [x]  ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in PhotoPrism
	- Introduced new Docker Compose configuration for PhotoPrism application

- **Chores**
	- Updated PhotoPrism configuration version
	- Updated application timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->