### PR TITLE
Add dynamic compose for stirling-pdf

### DIFF
--- a/apps/stirling-pdf/config.json
+++ b/apps/stirling-pdf/config.json
@@ -4,8 +4,9 @@
   "port": 8234,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "stirling-pdf",
-  "tipi_version": 63,
+  "tipi_version": 64,
   "version": "0.36.6",
   "categories": ["data", "utilities"],
   "description": "Locally hosted web application that allows you to perform various operations on PDF files.",
@@ -21,5 +22,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735858678000
+  "updated_at": 1736624921335
 }

--- a/apps/stirling-pdf/docker-compose.json
+++ b/apps/stirling-pdf/docker-compose.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "stirling-pdf",
+      "image": "stirlingtools/stirling-pdf:0.36.6",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "DOCKER_ENABLE_SECURITY": "${STIRLING_PDF_DOCKER_ENABLE_SECURITY-false}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/trainingData",
+          "containerPath": "/usr/share/tesseract-ocr/5/tessdata"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/extraConfigs",
+          "containerPath": "/configs"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/customFiles",
+          "containerPath": "/customFiles/"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/logs",
+          "containerPath": "/logs/"
+        }
+      ],
+      "privileged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for stirling-pdf
This is a stirling-pdf update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:
- [x] https://stirling-pdf.tipi.lan
##### In app tests :
  - [x] 📝 Docx to PDF
  - [x] 📖 PDF to Docx
    - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/trainingData:/usr/share/tesseract-ocr/5/tessdata
- [x] ${APP_DATA_DIR}/data/extraConfigs:/configs
- [x] ${APP_DATA_DIR}/data/customFiles:/customFiles/
- [x] ${APP_DATA_DIR}/data/logs:/logs/
##### Specific instructions verified :
- [x] 🌳 Environment (DOCKER_ENABLE_SECURITY=${STIRLING_PDF_DOCKER_ENABLE_SECURITY-false})
- [x] 👑 Privileged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic configuration in Stirling PDF
  - Introduced Docker Compose configuration for Stirling PDF service

- **Chores**
  - Updated Tipi version
  - Updated configuration timestamp
  - Deployed Stirling PDF version 0.36.6

- **Configuration**
  - Added volume mappings for training data, configs, custom files, and logs
  - Configured service to run with optional security settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->