### PR TITLE
Add dynamic compose for wikijs

### DIFF
--- a/apps/wikijs/config.json
+++ b/apps/wikijs/config.json
@@ -4,8 +4,9 @@
   "port": 8148,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "wikijs",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "2.5.305",
   "categories": ["media"],
   "description": "A modern, lightweight and powerful wiki app built on NodeJS ",
@@ -23,5 +24,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1729188336000
+  "updated_at": 1736624979936
 }

--- a/apps/wikijs/docker-compose.json
+++ b/apps/wikijs/docker-compose.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "wikijs",
+      "image": "ghcr.io/requarks/wiki:2.5.305",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "DB_TYPE": "postgres",
+        "DB_HOST": "wikijs-db",
+        "DB_PORT": 5432,
+        "DB_USER": "wikijs",
+        "DB_PASS": "${WIKI_JS_DB_PASS}",
+        "DB_NAME": "wiki"
+      },
+      "dependsOn": ["wikijs-db"]
+    },
+    {
+      "name": "wikijs-db",
+      "image": "postgres:11-alpine",
+      "environment": {
+        "POSTGRES_DB": "wiki",
+        "POSTGRES_PASSWORD": "${WIKI_JS_DB_PASS}",
+        "POSTGRES_USER": "wikijs"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "logging": {
+        "driver": "none",
+        "options": {}
+      }
+    }
+  ]
+}

--- a/apps/wikijs/docker-compose.json
+++ b/apps/wikijs/docker-compose.json
@@ -31,8 +31,7 @@
         }
       ],
       "logging": {
-        "driver": "none",
-        "options": {}
+        "driver": "none"
       }
     }
   ]


### PR DESCRIPTION
## Dynamic compose for wikijs
This is a wikijs update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app : 
- [x] http://localip:port
- [x] https://wikijs.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x] 📖 Write basic page
- [x] 🌆 Uploading image
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  📃 Logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in Wiki.js
	- Introduced Docker Compose configuration for Wiki.js and its PostgreSQL database
- **Chores**
	- Updated system version from 10 to 11
	- Updated configuration timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->