### PR TITLE
Add dynamic compose for netdata

### DIFF
--- a/apps/netdata/config.json
+++ b/apps/netdata/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 19999,
   "exposable": true,
+  "dynamic_config": true,
   "id": "netdata",
   "description": "Stream any metrics from every physical and virtual server, container and IoT device, to one dashboard, in real-time.",
-  "tipi_version": 31,
+  "tipi_version": 32,
   "version": "2.1.1",
   "categories": ["utilities"],
   "short_desc": "Open-source, real-time, performance and health monitoring.",
@@ -15,6 +16,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736506892000,
+  "updated_at": 1736624742117,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/netdata/docker-compose.json
+++ b/apps/netdata/docker-compose.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "netdata",
+      "image": "netdata/netdata:v2.1.1",
+      "isMain": true,
+      "internalPort": 19999,
+      "pid": "host",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/etc/netdata"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/lib",
+          "containerPath": "/var/lib/netdata"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/cache",
+          "containerPath": "/var/cache/netdata"
+        },
+        {
+          "hostPath": "/etc/passwd",
+          "containerPath": "/host/etc/passwd",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/etc/group",
+          "containerPath": "/host/etc/group",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/proc",
+          "containerPath": "/host/proc",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/sys",
+          "containerPath": "/host/sys",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/etc/os-release",
+          "containerPath": "/host/etc/os-release",
+          "readOnly": true
+        },
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock",
+          "readOnly": true
+        }
+      ],
+      "capAdd": ["SYS_PTRACE", "SYS_ADMIN"],
+      "securityOpt": ["apparmor:unconfined"]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for netdata
This is a netdata update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://netdata.tipi.lan
##### In app tests :
- [x]  📝 Register and log in
- [x]  🖱 Basic interaction
- [x]  🌆 Uploading data
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/config:/etc/netdata
- [x]  ${APP_DATA_DIR}/data/lib:/var/lib/netdata
- [x]  ${APP_DATA_DIR}/data/cache:/var/cache/netdata
- [x]  /etc/passwd:/host/etc/passwd:ro
- [x]  /etc/group:/host/etc/group:ro
- [x]  /proc:/host/proc:ro
- [x]  /sys:/host/sys:ro
- [x]  /etc/os-release:/host/etc/os-release:ro
- [x]  /var/run/docker.sock:/var/run/docker.sock:ro
##### Specific instructions :
- [x]  🔢 PID (host)
- [x]  🔓 Capacity add
- [x]   🔐 Security options