### PR TITLE
Add dynamic compose for glances

### DIFF
--- a/apps/glances/config.json
+++ b/apps/glances/config.json
@@ -4,8 +4,9 @@
   "port": 8420,
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "id": "glances",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "4.3.0.8-full",
   "categories": ["utilities"],
   "description": "Glances is an open-source system cross-platform monitoring tool. It allows real-time monitoring of various aspects of your system such as CPU, memory, disk, network usage etc.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1735996189000
+  "updated_at": 1736624628507
 }

--- a/apps/glances/docker-compose.json
+++ b/apps/glances/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "glances",
+      "image": "nicolargo/glances:4.3.0.8-full",
+      "isMain": true,
+      "internalPort": 61208,
+      "pid": "host",
+      "environment": {
+        "TZ": "${TZ}",
+        "GLANCES_OPT": "-w"
+      },
+      "volumes": [
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock",
+          "readOnly": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for glances
This is a glances update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://glances.tipi.lan
##### In app tests :
- [x] 📊 Check metrics
##### Volumes mapping verified :
- [x] /var/run/docker.sock:/var/run/docker.sock:ro
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 PID (host)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for the Glances application
  - Introduced new Docker Compose configuration for Glances service

- **Chores**
  - Updated Glances application version from 9 to 10
  - Updated configuration timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->