### PR TITLE
Add dynamic compose for forgejo

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -4,8 +4,9 @@
   "port": 8195,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 18,
+  "tipi_version": 19,
   "version": "1.21.11-0",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
@@ -22,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736624608519
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "forgejo",
+      "image": "codeberg.org/forgejo/forgejo:1.21.11-0",
+      "isMain": true,
+      "internalPort": 3000,
+      "addPorts": [
+        {
+          "hostPort": 222,
+          "containerPort": 22
+        }
+      ],
+      "environment": {
+        "USER_UID": "1000",
+        "USER_GID": "1000",
+        "FORGEJO__database__DB_TYPE": "postgres",
+        "FORGEJO__database__HOST": "forgejo-db:5432",
+        "FORGEJO__database__NAME": "forgejo",
+        "FORGEJO__database__USER": "forgejo",
+        "FORGEJO__database__PASSWD": "${FORGEJO_DB_PASSWORD}"
+      },
+      "dependsOn": ["forgejo-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/forgejo",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "forgejo-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_USER": "forgejo",
+        "POSTGRES_PASSWORD": "${FORGEJO_DB_PASSWORD}",
+        "POSTGRES_DB": "forgejo"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for forgejo
This is a forgejo update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8195
- [x] https://forgejo.tipi.lan
- [x] 22:222 (SSH)
##### In app tests :
- [x] 📝 Register and log in
- [x] ⌨ Create repository
- [x] 🐚 Copy git repository with SSH
  - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/forgejo:/data
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🔗 Depends on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Forgejo
  - Introduced Docker Compose configuration for Forgejo application and PostgreSQL database

- **Updates**
  - Upgraded Tipi version to 19
  - Updated Forgejo to version 1.21.11-0

- **Infrastructure**
  - Configured service deployment with mapped ports and persistent volumes
  - Set up database connection and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->