### PR TITLE
Add dynamic compose for owncloud

### DIFF
--- a/apps/owncloud/config.json
+++ b/apps/owncloud/config.json
@@ -4,8 +4,9 @@
   "port": 8151,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "owncloud",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "10.15.0",
   "categories": ["data"],
   "description": "ownCloud gives you freedom and control over your own data. A personal cloud which runs on your own server.  ",
@@ -39,5 +40,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736624785605
 }

--- a/apps/owncloud/docker-compose.json
+++ b/apps/owncloud/docker-compose.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "owncloud",
+      "image": "owncloud/server:10.15.0",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "OWNCLOUD_DOMAIN": "${APP_DOMAIN}",
+        "OWNCLOUD_TRUSTED_DOMAINS": "${APP_DOMAIN}",
+        "OWNCLOUD_DB_TYPE": "mysql",
+        "OWNCLOUD_DB_NAME": "owncloud",
+        "OWNCLOUD_DB_USERNAME": "tipi",
+        "OWNCLOUD_DB_PASSWORD": "${OWNCLOUD_DB_PASSWORD}",
+        "OWNCLOUD_DB_HOST": "owncloud-db",
+        "OWNCLOUD_ADMIN_USERNAME": "${OWNCLOUD_USERNAME}",
+        "OWNCLOUD_ADMIN_PASSWORD": "${OWNCLOUD_PASSWORD}",
+        "OWNCLOUD_MYSQL_UTF8MB4": "true",
+        "OWNCLOUD_REDIS_ENABLED": "true",
+        "OWNCLOUD_REDIS_HOST": "owncloud-redis"
+      },
+      "dependsOn": ["owncloud-db", "owncloud-redis"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/owncloud",
+          "containerPath": "/mnt/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 5,
+        "test": "/usr/bin/healthcheck"
+      }
+    },
+    {
+      "name": "owncloud-db",
+      "image": "mariadb:10.6",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "${OWNCLOUD_DB_PASSWORD}",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${OWNCLOUD_DB_PASSWORD}",
+        "MYSQL_DATABASE": "owncloud"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "command": ["--max-allowed-packet=128M", "--innodb-log-file-size=64M"],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "mysqladmin ping -u root --password=${OWNCLOUD_DB_PASSWORD}"
+      }
+    },
+    {
+      "name": "owncloud-redis",
+      "image": "redis:6",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": ["--databases", "1"],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for owncloud
This is a owncloud update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x]  [http://localip:port](http://localip:port)
- [x]  https://owncloud.tipi.local
##### In app tests :
- [x]  📝 Register and log in
- [x]  🌆 Upload files
- [x] 🏬 Install apps
- [x]  🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/owncloud:/mnt/data
- [x] ${APP_DATA_DIR}/data/mysql:/var/lib/mysql
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x]  🌳 Environment
- [x]  🩺 Healthcheck
- [x]  🔗 Depends on
- [x]  ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OwnCloud application configuration with dynamic configuration support
  - Introduced Docker Compose deployment configuration for OwnCloud, including database and Redis services

- **Chores**
  - Updated OwnCloud application version
  - Updated configuration timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->