### PR TITLE
Add dynamic compose for rallly

### DIFF
--- a/apps/rallly/config.json
+++ b/apps/rallly/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "port": 8208,
   "exposable": true,
+  "dynamic_config": true,
   "id": "rallly",
   "description": "Rallly is an open-source scheduling and collaboration tool designed to make organizing events and meetings easier.",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "3.11.2",
   "categories": ["utilities"],
   "short_desc": "Scheduling and collaboration tool",
@@ -100,5 +101,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1729521953000
+  "updated_at": 1736624841809
 }

--- a/apps/rallly/docker-compose.json
+++ b/apps/rallly/docker-compose.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "rallly",
+      "image": "lukevella/rallly:3.11.2",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "DATABASE_URL": "postgres://tipi:${RALLLY_DB_PASSWORD}@rallly_db:5432/rallly",
+        "SECRET_PASSWORD": "${RALLLY_SECRET_KEY}",
+        "NEXT_PUBLIC_BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "NOREPLY_EMAIL": "${RALLLY_NOREPLY_EMAIL}",
+        "SUPPORT_EMAIL": "${RALLLY_SUPPORT_EMAIL}",
+        "SMTP_HOST": "${RALLLY_SMTP_HOST}",
+        "SMTP_PORT": "${RALLLY_SMTP_PORT}",
+        "SMTP_SECURE": "${RALLLY_SMTP_SECURE}",
+        "SMTP_USER": "${RALLLY_SMTP_USER}",
+        "SMTP_PWD": "${RALLLY_SMTP_PWD}",
+        "SMTP_TLS_ENABLED": "${RALLLY_SMTP_TLS_ENABLED}",
+        "ALLOWED_EMAILS": "${RALLLY_ALLOWED_EMAILS}"
+      },
+      "dependsOn": {
+        "rallly_db": {
+          "condition": "service_healthy"
+        }
+      }
+    },
+    {
+      "name": "rallly_db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_PASSWORD": "${RALLLY_DB_PASSWORD}",
+        "POSTGRES_DB": "rallly",
+        "POSTGRES_USER": "tipi"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "5s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready -U tipi"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for rallly
This is a rallly update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8208 (not allowed)
- [x] https://rallly.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x] 🌆 Create poll
- [x] 🌐 Access and answer poll through invite
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added support for dynamic configuration
	- Updated Tipi framework version to 14
	- Updated configuration timestamp

- **Infrastructure**
	- Added Docker Compose configuration for Rallly application
	- Set up Rallly service with version 3.11.2
	- Configured PostgreSQL database service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->