### PR TITLE
Add dynamic compose for movary

### DIFF
--- a/apps/movary/config.json
+++ b/apps/movary/config.json
@@ -4,10 +4,11 @@
   "port": 8155,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "uid": 1000,
   "gid": 1000,
   "id": "movary",
-  "tipi_version": 34,
+  "tipi_version": 35,
   "version": "0.62.2",
   "categories": ["media"],
   "description": "Movary is a self-hosted web application to track and rate your watched movies (like a digital movie diary). You can import/export your history and ratings from/to third parties like trakt.tv or letterboxd.com, scrobble your watches via Plex and Jellyfin and more.",
@@ -43,5 +44,5 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192
+  "updated_at": 1736624718771
 }

--- a/apps/movary/docker-compose.json
+++ b/apps/movary/docker-compose.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "movary",
+      "image": "leepeuker/movary:0.62.2",
+      "isMain": true,
+      "internalPort": 80,
+      "user": "1000:1000",
+      "environment": {
+        "TMDB_API_KEY": "${MOVARY_TMDB_API_KEY}",
+        "TIMEZONE": "${TZ}",
+        "DATABASE_MODE": "mysql",
+        "DATABASE_MYSQL_HOST": "movary-db",
+        "DATABASE_MYSQL_NAME": "movary",
+        "DATABASE_MYSQL_USER": "tipi",
+        "DATABASE_MYSQL_PASSWORD": "${MOVARY_MYSQL_PASSWORD}",
+        "TMDB_ENABLE_IMAGE_CACHING": "1",
+        "APPLICATION_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "PLEX_IDENTIFIER": "${MOVARY_PLEX_IDENTIFIER}",
+        "JELLYFIN_DEVICE_ID": "${MOVARY_JELLYFIN_IDENTIFIER}"
+      },
+      "dependsOn": {
+        "movary-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/movary",
+          "containerPath": "/app/storage"
+        }
+      ]
+    },
+    {
+      "name": "movary-migration",
+      "image": "leepeuker/movary:0.62.2",
+      "user": "1000:1000",
+      "environment": {
+        "TMDB_API_KEY": "${MOVARY_TMDB_API_KEY}",
+        "TIMEZONE": "${TZ}",
+        "DATABASE_MODE": "mysql",
+        "DATABASE_MYSQL_HOST": "movary-db",
+        "DATABASE_MYSQL_NAME": "movary",
+        "DATABASE_MYSQL_USER": "tipi",
+        "DATABASE_MYSQL_PASSWORD": "${MOVARY_MYSQL_PASSWORD}",
+        "TMDB_ENABLE_IMAGE_CACHING": "1",
+        "APPLICATION_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "PLEX_IDENTIFIER": "${MOVARY_PLEX_IDENTIFIER}",
+        "JELLYFIN_DEVICE_ID": "${MOVARY_JELLYFIN_IDENTIFIER}"
+      },
+      "dependsOn": {
+        "movary-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/movary",
+          "containerPath": "/app/storage"
+        }
+      ],
+      "command": "php bin/console.php database:migration:migrate"
+    },
+    {
+      "name": "movary-db",
+      "image": "mysql:8.0",
+      "environment": {
+        "MYSQL_DATABASE": "movary",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${MOVARY_MYSQL_PASSWORD}",
+        "MYSQL_ROOT_PASSWORD": "${MOVARY_MYSQL_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "healthCheck": {
+        "timeout": "20s",
+        "retries": 10,
+        "test": "mysqladmin ping -h localhost"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for movary
This is a movary update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://movary.tipi.local
##### In app tests :
- [x]  📝 Register and log in
- [x]  🔎 Search a movie
- [x]  🎬 Connect to Jellyfin
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/movary:/app/storage
- [x]  ${APP_DATA_DIR}/data/movary:/app/storage
- [x]  ${APP_DATA_DIR}/data/mysql:/var/lib/mysql
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (1000:1000)
- [x]  🔗 Depends on
- [x]  ⌨ Command
- [x]  🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support
	- Updated Tipi version from 34 to 35
	- Updated application timestamp

- **Infrastructure**
	- Introduced new Docker Compose configuration
	- Added services for Movary application, database migrations, and MySQL database
	- Configured application with version 0.62.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->