### PR TITLE
Add dynamic compose for gotosocial

### DIFF
--- a/apps/gotosocial/config.json
+++ b/apps/gotosocial/config.json
@@ -37,7 +37,7 @@
           "value": "false"
         }
       ],
-      "env_variable": "GTS_ACCOUNTS_REGISTRATION_OPE"
+      "env_variable": "GTS_ACCOUNTS_REGISTRATION_OPEN"
     },
     {
       "type": "text",
@@ -61,7 +61,7 @@
       "env_variable": "GTS_SMTP_USERNAME"
     },
     {
-      "type": "text",
+      "type": "password",
       "label": "SMTP Password",
       "hint": "Your SMTP Server Password",
       "required": false,

--- a/apps/gotosocial/config.json
+++ b/apps/gotosocial/config.json
@@ -4,9 +4,10 @@
   "port": 8188,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "force_expose": true,
   "id": "gotosocial",
-  "tipi_version": 23,
+  "tipi_version": 24,
   "uid": 1000,
   "gid": 1000,
   "version": "0.17.3",
@@ -76,5 +77,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730917453000
+  "updated_at": 1736624632460
 }

--- a/apps/gotosocial/docker-compose.json
+++ b/apps/gotosocial/docker-compose.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "gotosocial",
+      "image": "superseriousbusiness/gotosocial:0.17.3",
+      "isMain": true,
+      "internalPort": 8080,
+      "user": "1000:1000",
+      "environment": {
+        "GTS_HOST": "${APP_DOMAIN}",
+        "GTS_LETSENCRYPT_ENABLED": "false",
+        "GTS_DB_TYPE": "postgres",
+        "GTS_DB_ADDRESS": "gotosocial-db",
+        "GTS_DB_PORT": "5432",
+        "GTS_DB_USER": "tipi",
+        "GTS_DB_PASSWORD": "${GTS_DB_PASSWORD}",
+        "GTS_DB_DATABASE": "gotosocial-db",
+        "GTS_ACCOUNTS_REGISTRATION_OPEN": "${GTS_ACCOUNTS_REGISTRATION_OPEN}",
+        "GTS_SMTP_HOST": "${GTS_SMTP_HOST}",
+        "GTS_SMTP_PORT": "${GTS_SMTP_PORT}",
+        "GTS_SMTP_USERNAME": "${GTS_SMTP_USERNAME}",
+        "GTS_SMTP_PASSWORD": "${GTS_SMTP_PASSWORD}",
+        "GTS_SMTP_FROM": "${GTS_SMTP_FROM}"
+      },
+      "dependsOn": ["gotosocial-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/gotosocial",
+          "containerPath": "/gotosocial/storage"
+        }
+      ]
+    },
+    {
+      "name": "gotosocial-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_PASSWORD": "${GTS_DB_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "gotosocial-db",
+        "PG_DATA": "/var/lib/postgresql/data"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for gotosocial
This is a gotosocial update for using dynamic compose. (no other change)
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://gotosocial.tipi.local
- [x] https://gotosocial.domain.com
##### In app tests :
- [x]  📝 Register
- [x]  🐘 Log in through Mastodon app
- [x]  ✍ Write post
- [x]  🌆 Add photos
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/gotosocial:/gotosocial/storage
- [x]  ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (1000:1000)
- [x]  🔗 Depends on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated application version to 24
	- Corrected registration settings environment variable
	- Changed SMTP password field to secure password input
	- Added dynamic configuration support

- **Infrastructure**
	- Introduced new Docker Compose configuration
	- Set up GoToSocial application with PostgreSQL backend
	- Configured service dependencies and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->