### PR TITLE
update config.json to change SMTP host field type

### DIFF
--- a/apps/calcom/config.json
+++ b/apps/calcom/config.json
@@ -68,7 +68,7 @@
       "type": "email"
     },
     {
-      "type": "email",
+      "type": "text",
       "label": "Email server username (SMTP)",
       "required": true,
       "min": 1,


### PR DESCRIPTION
change SMTP host field type from "email" to "text" for more convenience use case (e,g: smtp username not an email address form)