### PR TITLE
cyberchef - remove arm64 (unsupported)

### DIFF
--- a/apps/cyberchef/config.json
+++ b/apps/cyberchef/config.json
@@ -12,7 +12,7 @@
   "tipi_version": 6,
   "version": "10.19.4",
   "source": "https://github.com/gchq/CyberChef",
-  "supported_architectures": ["arm64", "amd64"],
+  "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
   "updated_at": 1729872626158,
   "$schema": "../app-info-schema.json"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Removed ARM64 architecture support for CyberChef application
	- Now supports only AMD64 architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->