### PR TITLE
Add dynamic compose for unmanic + change docker tag

### DIFF
--- a/apps/unmanic/config.json
+++ b/apps/unmanic/config.json
@@ -4,8 +4,9 @@
   "port": 8256,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "unmanic",
-  "tipi_version": 6,
+  "tipi_version": 7,
   "version": "0.2.8",
   "categories": ["utilities", "data", "media"],
   "description": "Unmanic gives you the power to automate the management of any file library.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724903264000
+  "updated_at": 1736624969900
 }

--- a/apps/unmanic/config.json
+++ b/apps/unmanic/config.json
@@ -7,7 +7,7 @@
   "dynamic_config": true,
   "id": "unmanic",
   "tipi_version": 7,
-  "version": "0.2.8",
+  "version": "staging",
   "categories": ["utilities", "data", "media"],
   "description": "Unmanic gives you the power to automate the management of any file library.",
   "short_desc": "Unmanic - Library Optimiser.",

--- a/apps/unmanic/docker-compose.json
+++ b/apps/unmanic/docker-compose.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "unmanic",
+      "image": "josh5/unmanic:0.2.8",
+      "isMain": true,
+      "internalPort": 8888,
+      "environment": {
+        "PUID": "${TIPI_UID}",
+        "PGID": "${TIPI_GID}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data",
+          "containerPath": "/library"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/temp",
+          "containerPath": "/tmp/unmanic"
+        }
+      ],
+      "privileged": true
+    }
+  ]
+}

--- a/apps/unmanic/docker-compose.json
+++ b/apps/unmanic/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "unmanic",
-      "image": "josh5/unmanic:0.2.8",
+      "image": "josh5/unmanic:staging",
       "isMain": true,
       "internalPort": 8888,
       "environment": {

--- a/apps/unmanic/docker-compose.yml
+++ b/apps/unmanic/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   unmanic:
-    image: josh5/unmanic:0.2.8
+    image: josh5/unmanic:staging
     restart: unless-stopped
     container_name: unmanic
     privileged: true


### PR DESCRIPTION
## Dynamic compose for unmanic + update
This is a unmanic update for using dynamic compose + change docker tag to staging
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:port
- [x] https://unmanic.tipi.lan
##### In app tests :
- [x] 🔎 Basic scan
  - [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${ROOT_FOLDER_HOST}/media/data:/library
- [x] ${APP_DATA_DIR}/data/temp:/tmp/unmanic
##### Specific instructions :
- [x] 🌳 Environment
- [x] 👑 Privileged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Unmanic application

- **Version Updates**
  - Updated Tipi version from 6 to 7
  - Transitioned Unmanic application to staging version

- **Configuration Changes**
  - Modified Docker Compose configuration to use staging Docker image
  - Updated configuration timestamp
<!-- end of auto-generated comment: release notes by coderabbit.ai -->