### PR TITLE
Add dynamic compose for ghostfolio

### DIFF
--- a/apps/ghostfolio/config.json
+++ b/apps/ghostfolio/config.json
@@ -4,8 +4,9 @@
   "port": 3333,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "ghostfolio",
-  "tipi_version": 136,
+  "tipi_version": 137,
   "version": "2.134.0",
   "categories": ["finance"],
   "description": "Ghostfolio is a privacy-first, open source dashboard for your personal finances.",
@@ -44,5 +45,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736975548000
+  "updated_at": 1736983438924
 }

--- a/apps/ghostfolio/docker-compose.json
+++ b/apps/ghostfolio/docker-compose.json
@@ -48,7 +48,7 @@
         "interval": "10s",
         "timeout": "5s",
         "retries": 5,
-        "test": "pg_isready -d ghostfolio"
+        "test": "pg_isready -d ghostfolio -U ghostfolio"
       }
     },
     {
@@ -60,7 +60,7 @@
           "containerPath": "/data"
         }
       ],
-      "command": "--requirepass ${GHOSTFOLIO_REDIS_PASSWORD}\n",
+      "command": "--requirepass ${GHOSTFOLIO_REDIS_PASSWORD}",
       "healthCheck": {
         "interval": "10s",
         "timeout": "5s",

--- a/apps/ghostfolio/docker-compose.json
+++ b/apps/ghostfolio/docker-compose.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "ghostfolio",
+      "image": "ghostfolio/ghostfolio:2.134.0",
+      "isMain": true,
+      "internalPort": 3333,
+      "environment": {
+        "NODE_ENV": "production",
+        "HOST": "0.0.0.0",
+        "PORT": 3333,
+        "ACCESS_TOKEN_SALT": "$GHOSTFOLIO_ACCESS_TOKEN_SALT",
+        "DATABASE_URL": "postgresql://ghostfolio:${GHOSTFOLIO_DB_PASSWORD}@ghostfolio-db:5432/ghostfolio?sslmode=prefer",
+        "JWT_SECRET_KEY": "${GHOSTFOLIO_JWT_SECRET_KEY}",
+        "POSTGRES_DB": "ghostfolio",
+        "POSTGRES_USER": "ghostfolio",
+        "POSTGRES_PASSWORD": "${GHOSTFOLIO_DB_PASSWORD}",
+        "REDIS_HOST": "ghostfolio-redis",
+        "REDIS_PASSWORD": "${GHOSTFOLIO_REDIS_PASSWORD}",
+        "REDIS_PORT": 6379
+      },
+      "dependsOn": {
+        "ghostfolio-db": {
+          "condition": "service_healthy"
+        },
+        "ghostfolio-redis": {
+          "condition": "service_healthy"
+        }
+      }
+    },
+    {
+      "name": "ghostfolio-db",
+      "image": "postgres:15.4-alpine",
+      "environment": {
+        "POSTGRES_DB": "ghostfolio",
+        "POSTGRES_USER": "ghostfolio",
+        "POSTGRES_PASSWORD": "${GHOSTFOLIO_DB_PASSWORD}",
+        "PGDATA": "/var/lib/postgresql/data"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready -d ghostfolio"
+      }
+    },
+    {
+      "name": "ghostfolio-redis",
+      "image": "redis:7-alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "--requirepass ${GHOSTFOLIO_REDIS_PASSWORD}\n",
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for ghostfolio
This is a ghostfolio update for using dynamic compose.
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://ghostfolio.tipi.local
##### In app tests :
- [x]  📝 Register and log in with token
- [x]  💲 Add random data
- [x]  📊 Check virtual wealth metric
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
- [x]  ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  🩺 Healthcheck (fixed)
- [x]  ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Enabled dynamic configuration for Ghostfolio
	- Updated application version to 2.137
	- Updated configuration timestamp

- **Infrastructure**
	- Added Docker Compose configuration for Ghostfolio
	- Introduced services for Ghostfolio application, PostgreSQL database, and Redis cache
	- Configured production environment settings and service dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->