### PR TITLE
Remove usage of docker.io registry

### DIFF
--- a/apps/bitmagnet/docker-compose.json
+++ b/apps/bitmagnet/docker-compose.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "image": "docker.io/library/postgres:17-alpine",
+      "image": "postgres:17-alpine",
       "name": "bitmagnet-db",
       "volumes": [
         {
@@ -58,7 +58,7 @@
       }
     },
     {
-      "image": "docker.io/library/redis:alpine",
+      "image": "redis:alpine",
       "name": "bitmagnet-redis",
       "command": "--save 60 1 --loglevel warning",
       "volumes": [

--- a/apps/bitmagnet/docker-compose.yml
+++ b/apps/bitmagnet/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       runtipi.managed: true
   bitmagnet-db:
     container_name: bitmagnet-db
-    image: docker.io/library/postgres:17-alpine
+    image: postgres:17-alpine
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
@@ -76,7 +76,7 @@ services:
     labels:
       runtipi.managed: true
   bitmagnet-redis:
-    image: docker.io/library/redis:alpine
+    image: redis:alpine
     command: --save 60 1 --loglevel warning
     container_name: bitmagnet-redis
     restart: unless-stopped

--- a/apps/paperless-ngx/docker-compose.json
+++ b/apps/paperless-ngx/docker-compose.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "broker",
-      "image": "docker.io/library/redis:7",
+      "image": "redis:7",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/redis",
@@ -49,7 +49,7 @@
     },
     {
       "name": "db",
-      "image": "docker.io/library/postgres:17",
+      "image": "postgres:17",
       "environment": {
         "POSTGRES_DB": "paperless",
         "POSTGRES_USER": "paperless",
@@ -64,7 +64,7 @@
     },
     {
       "name": "gotenberg",
-      "image": "docker.io/gotenberg/gotenberg:8.14",
+      "image": "gotenberg/gotenberg:8.14",
       "command": ["gotenberg", "--chromium-disable-javascript=true", "--chromium-allow-list=file:///tmp/.*"]
     },
     {

--- a/apps/paperless-ngx/docker-compose.yml
+++ b/apps/paperless-ngx/docker-compose.yml
@@ -60,7 +60,7 @@ services:
 
   # Redis
   broker:
-    image: docker.io/library/redis:7
+    image: redis:7
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data/redis:/data
@@ -69,7 +69,7 @@ services:
     labels:
       runtipi.managed: true
   db:
-    image: docker.io/library/postgres:17
+    image: postgres:17
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
@@ -82,7 +82,7 @@ services:
     labels:
       runtipi.managed: true
   gotenberg:
-    image: docker.io/gotenberg/gotenberg:8.15
+    image: gotenberg/gotenberg:8.15
     restart: unless-stopped
     # The gotenberg chromium route is used to convert .eml files. We do not
     # want to allow external content like tracking pixels or even javascript.

--- a/apps/sftpgo/docker-compose.yml
+++ b/apps/sftpgo/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       runtipi.managed: true
   sftpgo-db:
     container_name: sftpgo-db
-    image: docker.io/library/postgres:17.2-alpine
+    image: postgres:17.2-alpine
     restart: unless-stopped
     networks:
       - tipi_main_network

--- a/apps/shlink/docker-compose.json
+++ b/apps/shlink/docker-compose.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "shlink-db",
-      "image": "docker.io/library/postgres:17.2-alpine",
+      "image": "postgres:17.2-alpine",
       "environment": {
         "POSTGRES_PASSWORD": "${SHLINK_POSTGRES_PASSWORD}",
         "POSTGRES_USER": "shlink",

--- a/apps/shlink/docker-compose.yml
+++ b/apps/shlink/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       runtipi.managed: true
   shlink-db:
     container_name: shlink-db
-    image: docker.io/library/postgres:17.2-alpine
+    image: postgres:17.2-alpine
     restart: unless-stopped
     networks:
       - tipi_main_network


### PR DESCRIPTION
There's no need to explicitly mention `docker.io` as it's just a proxy to Docker Hub which is the default registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified Docker image references across multiple applications by removing `docker.io/library/` prefix
	- Updated image references for PostgreSQL, Redis, and Gotenberg services in Bitmagnet, Paperless-NGX, SFTPgo, and Shlink configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->