### PR TITLE
Add dynamic compose flowise (and fix paths)

### DIFF
--- a/apps/flowise/config.json
+++ b/apps/flowise/config.json
@@ -3,9 +3,10 @@
   "name": "Flowise AI",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8009,
   "id": "flowise",
-  "tipi_version": 39,
+  "tipi_version": 40,
   "version": "2.2.4",
   "categories": ["ai", "automation"],
   "description": "Flowise AI is an Open source UI visual tool to build your customized LLM ochestration flow & AI agents. Developing LLM apps takes countless iterations. With low code approach, Flowise AI enable quick iterations to go from testing to production.",
@@ -74,5 +75,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736891413000
+  "updated_at": 1736983416166
 }

--- a/apps/flowise/docker-compose.json
+++ b/apps/flowise/docker-compose.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "flowise",
+      "image": "flowiseai/flowise:2.2.4",
+      "isMain": true,
+      "internalPort": 8009,
+      "environment": {
+        "PORT": "8009",
+        "FLOWISE_USERNAME": "${FLOWISE_USERNAME}",
+        "FLOWISE_PASSWORD": "${FLOWISE_PASSWORD}",
+        "FLOWISE_SECRETKEY_OVERWRITE": "${FLOWISE_SECRETKEY_OVERWRITE}",
+        "LANGCHAIN_ENDPOINT": "${LANGCHAIN_ENDPOINT}",
+        "LANGCHAIN_API_KEY": "${LANGCHAIN_API_KEY}",
+        "LANGCHAIN_PROJECT": "${LANGCHAIN_PROJECT}",
+        "LANGCHAIN_TRACING_V2": "${LANGCHAIN_TRACING_V2}",
+        "DISABLE_FLOWISE_TELEMETRY": "${DISABLE_FLOWISE_TELEMETRY}",
+        "DATABASE_PATH": "/root/.flowise",
+        "APIKEY_PATH": "/root/.flowise",
+        "SECRETKEY_PATH": "/root/.flowise/logs",
+        "LOG_PATH": "/root/.flowise"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/flowise",
+          "containerPath": "/root/.flowise"
+        }
+      ],
+      "entrypoint": "/bin/sh -c \"sleep 3; flowise start\""
+    }
+  ]
+}

--- a/apps/flowise/docker-compose.json
+++ b/apps/flowise/docker-compose.json
@@ -18,8 +18,8 @@
         "DISABLE_FLOWISE_TELEMETRY": "${DISABLE_FLOWISE_TELEMETRY}",
         "DATABASE_PATH": "/root/.flowise",
         "APIKEY_PATH": "/root/.flowise",
-        "SECRETKEY_PATH": "/root/.flowise/logs",
-        "LOG_PATH": "/root/.flowise"
+        "SECRETKEY_PATH": "/root/.flowise",
+        "LOG_PATH": "/root/.flowise/logs"
       },
       "volumes": [
         {

--- a/apps/flowise/docker-compose.yml
+++ b/apps/flowise/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - DISABLE_FLOWISE_TELEMETRY=${DISABLE_FLOWISE_TELEMETRY}
       - DATABASE_PATH=/root/.flowise
       - APIKEY_PATH=/root/.flowise
-      - SECRETKEY_PATH=/root/.flowise/logs
-      - LOG_PATH=/root/.flowise
+      - SECRETKEY_PATH=/root/.flowise
+      - LOG_PATH=/root/.flowise/logs
     ports:
       - ${APP_PORT}:8009
     volumes:


### PR DESCRIPTION
## Dynamic compose for flowise
This is a flowise update for using dynamic compose. (and environment paths fixes)
##### Reaching the app :
- [x]  [http://localip:port](http://localip:port)
- [x]  [https://flowise.tipi.local](https://flowise.tipi.local)
##### In app tests :
- [x]  📝 Register agents
- [x]  🔨 Create a worflow
- [x]  🤖 Play with AI
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/flowise:/root/.flowise
##### Specific instructions :
- [x]  🌳 Environment (paths fixed)
- [x]  🚪 Entrypoint (/bin/sh -c "sleep 3; flowise start")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support for Flowise AI
	- Updated Tipi version to 40
	- Modified configuration timestamp

- **Docker Configuration**
	- Introduced new Docker Compose configuration for Flowise
	- Updated logging path for improved log management
	- Configured service with Flowise image version 2.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->