### PR TITLE
Add dynamic compose for your-spotify

### DIFF
--- a/apps/your-spotify/config.json
+++ b/apps/your-spotify/config.json
@@ -3,9 +3,10 @@
   "name": "Your Spotify",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8103,
   "id": "your-spotify",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "1.12.0",
   "categories": ["music", "utilities"],
   "description": "Self hosted Spotify tracking dashboard.",
@@ -30,5 +31,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734003921000
+  "updated_at": 1736983963658
 }

--- a/apps/your-spotify/docker-compose.json
+++ b/apps/your-spotify/docker-compose.json
@@ -26,7 +26,7 @@
         "SPOTIFY_PUBLIC": "${SPOTIFY_PUBLIC}",
         "SPOTIFY_SECRET": "${SPOTIFY_SECRET}",
         "MONGO_ENDPOINT": "mongodb://your-spotify-db:27017/your_spotify",
-        "CORS": "all"
+        "CORS": "i-want-a-security-vulnerability-and-want-to-allow-all-origins"
       },
       "dependsOn": ["your-spotify-db"]
     },

--- a/apps/your-spotify/docker-compose.json
+++ b/apps/your-spotify/docker-compose.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "your-spotify",
+      "image": "yooooomi/your_spotify_client:1.12.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "API_ENDPOINT": "http://${INTERNAL_IP}:32500"
+      },
+      "dependsOn": ["your-spotify-server"]
+    },
+    {
+      "name": "your-spotify-server",
+      "image": "yooooomi/your_spotify_server",
+      "addPorts": [
+        {
+          "hostPort": 32500,
+          "containerPort": 8080
+        }
+      ],
+      "environment": {
+        "API_ENDPOINT": "http://${INTERNAL_IP}:32500",
+        "CLIENT_ENDPOINT": "http://${INTERNAL_IP}:${APP_PORT}",
+        "SPOTIFY_PUBLIC": "${SPOTIFY_PUBLIC}",
+        "SPOTIFY_SECRET": "${SPOTIFY_SECRET}",
+        "MONGO_ENDPOINT": "mongodb://your-spotify-db:27017/your_spotify",
+        "CORS": "all"
+      },
+      "dependsOn": ["your-spotify-db"]
+    },
+    {
+      "name": "your-spotify-db",
+      "image": "mongo:4.4.8",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/data/db"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for your-spotify
This is a your-spotify update for using dynamic compose.
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://your-spotify.tipi.local
- [x]  Additionnal Port(s)
##### In app tests :
- [x]  📝 Register spotify app and log in
- [x]  🖱 Basic interaction
- [x]  🌆 Uploading listening history export
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/db:/data/db
##### Specific instructions :
- [x]  🌳 Environment (updated CORS)
- [x]  🔗 Depends on
- 🏷 DNS (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration support for Your Spotify
	- Introduced Docker Compose configuration for multi-container deployment

- **Updates**
	- Upgraded Tipi version to 17
	- Updated Your Spotify client to version 1.12.0
	- Updated configuration timestamp

- **Infrastructure**
	- Set up new services for client, server, and database
	- Configured service interconnectivity and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->