### PR TITLE
Add dynamic compose for transmission

### DIFF
--- a/apps/transmission/config.json
+++ b/apps/transmission/config.json
@@ -3,12 +3,15 @@
   "name": "Transmission",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8089,
   "requirements": {
-    "ports": [51413]
+    "ports": [
+      51413
+    ]
   },
   "id": "transmission",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "4.0.6",
   "categories": ["utilities"],
   "description": "Transmission is a fast, easy, and free BitTorrent client.",
@@ -35,5 +38,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736983904060
 }

--- a/apps/transmission/config.json
+++ b/apps/transmission/config.json
@@ -6,9 +6,7 @@
   "dynamic_config": true,
   "port": 8089,
   "requirements": {
-    "ports": [
-      51413
-    ]
+    "ports": [51413]
   },
   "id": "transmission",
   "tipi_version": 11,

--- a/apps/transmission/docker-compose.json
+++ b/apps/transmission/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "transmission",
+      "image": "lscr.io/linuxserver/transmission:4.0.6",
+      "isMain": true,
+      "internalPort": 9091,
+      "addPorts": [
+        {
+          "hostPort": 51413,
+          "containerPort": 51413,
+          "udp": true
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "USER": "${TRANSMISSION_USERNAME}",
+        "PASS": "${TRANSMISSION_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents",
+          "containerPath": "/media/torrents"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/transmission/docker-compose.json
+++ b/apps/transmission/docker-compose.json
@@ -10,7 +10,8 @@
         {
           "hostPort": 51413,
           "containerPort": 51413,
-          "udp": true
+          "udp": true,
+          "tcp": true
         }
       ],
       "environment": {


### PR DESCRIPTION
## Dynamic compose for transmission
This is a transmission update for using dynamic compose. (no other change)
##### Reaching the app :
- [x] App reachable as intended (WebUI)
  - [x] http://localip:port
  - [x] https://localdomain.tld
- [x] Additionnals ports are mapped correctly
  - [x] 51413:51413 (TCP & UDP)
##### In app tests :
- [x] 📝 Add torrents
- [x] 🌊 Check after a full download
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
##### Specific instructions verified :
- [x] 🌳 Environment (PUID,PGID,TZ,USER,PASS)
- 🌐 DNS (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support for Transmission
	- Updated Transmission configuration version
	- Modified configuration timestamp

- **New Features**
	- Introduced Docker Compose configuration for Transmission service
	- Configured service with port mappings and environment variables
	- Set up volume mappings for configuration and media torrents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->