### PR TITLE
Add dynamic compose for wordpress

### DIFF
--- a/apps/wordpress/config.json
+++ b/apps/wordpress/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8213,
   "exposable": true,
+  "dynamic_config": true,
   "id": "wordpress",
   "description": "WordPress is a popular content management system for creating websites and blogs.",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "6.7.1",
   "categories": ["social"],
   "short_desc": "Popular CMS for websites and blogs",
@@ -28,6 +29,6 @@
   ],
   "supported_architectures": ["amd64", "arm64"],
   "created_at": 1691943801422,
-  "updated_at": 1732255887000,
+  "updated_at": 1736983948612,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/wordpress/docker-compose.json
+++ b/apps/wordpress/docker-compose.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "wordpress",
+      "image": "wordpress:6.7.1",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "WORDPRESS_DB_HOST": "wordpress-db",
+        "WORDPRESS_DB_NAME": "wordpress",
+        "WORDPRESS_DB_USER": "tipi",
+        "WORDPRESS_DB_PASSWORD": "${DB_PASSWORD}"
+      },
+      "dependsOn": ["wordpress-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/wordpress",
+          "containerPath": "/var/www/html"
+        }
+      ]
+    },
+    {
+      "name": "wordpress-db",
+      "image": "mariadb:11.1.3",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "${DB_ROOT_PASSWORD}",
+        "MYSQL_DATABASE": "wordpress",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mariadb",
+          "containerPath": "/var/lib/mysql"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for wordpress
This is a wordpress update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8213
- [x] https://wordpress.tipi.lan
##### In app tests :
- [x] 📝 Register
- [x] 📰 Create a website
- [x] 🖼 Add pictures
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/wordpress:/var/www/html
- [x] ${APP_DATA_DIR}/data/mariadb:/var/lib/mysql
##### Specific instructions verified :
- [x] 🌳 Environment (WORDPRESS_DB_HOST, WORDPRESS_DB_NAME, WORDPRESS_DB_USER, WORDPRESS_DB_PASSWORD)
- [x]  🔗 Depends on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated WordPress configuration with dynamic config support
	- Incremented Tipi version to 14

- **New Features**
	- Added Docker Compose configuration for WordPress deployment
	- Configured WordPress and MariaDB services with environment-specific settings

- **Infrastructure**
	- Implemented containerized WordPress setup with database integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->