### PR TITLE
Add dynamic compose for planka (and fix the app)

### DIFF
--- a/apps/planka/config.json
+++ b/apps/planka/config.json
@@ -4,8 +4,9 @@
   "port": 8016,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "planka",
-  "tipi_version": 44,
+  "tipi_version": 45,
   "version": "1.24.3",
   "categories": ["development"],
   "description": "The realtime kanban board for workgroups built with React and Redux.",
@@ -23,5 +24,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1732813951000
+  "updated_at": 1736983694345
 }

--- a/apps/planka/config.json
+++ b/apps/planka/config.json
@@ -16,6 +16,37 @@
   "website": "https://docs.planka.cloud/",
   "form_fields": [
     {
+      "type": "email",
+      "label": "Admin email",
+      "max": 50,
+      "min": 3,
+      "required": true,
+      "env_variable": "PLANKA_ADMIN_EMAIL"
+    },
+    {
+      "type": "text",
+      "label": "Admin name",
+      "max": 50,
+      "min": 3,
+      "required": true,
+      "env_variable": "PLANKA_ADMIN_NAME"
+    },
+    {
+      "type": "text",
+      "label": "Admin username",
+      "max": 50,
+      "min": 3,
+      "required": true,
+      "env_variable": "PLANKA_ADMIN_USERNAME"
+    },
+    {
+      "type": "password",
+      "label": "Admin password",
+      "max": 50,
+      "required": true,
+      "env_variable": "PLANKA_ADMIN_PASSWORD"
+    },
+    {
       "type": "random",
       "label": "Planka Secret Key",
       "min": 32,

--- a/apps/planka/docker-compose.json
+++ b/apps/planka/docker-compose.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "planka",
+      "image": "ghcr.io/plankanban/planka:1.24.3",
+      "isMain": true,
+      "internalPort": 1337,
+      "environment": {
+        "BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "TRUST_PROXY": "1",
+        "DATABASE_URL": "\"postgresql://postgres@postgres/planka\"",
+        "SECRET_KEY": "\"${PLANKA_SECRET_KEY}\""
+      },
+      "dependsOn": ["postgres"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/user-avatars",
+          "containerPath": "/app/public/user-avatars"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/project-background-images",
+          "containerPath": "/app/public/project-background-images"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/attachments",
+          "containerPath": "/app/private/attachments"
+        }
+      ],
+      "command": "bash -c\n  \"for i in `seq 1 30`; do\n    ./start.sh &&\n    s=$$? && break || s=$$?;\n    echo \\\"Tried $$i times. Waiting 5 seconds...\\\";\n    sleep 5;\n  done; (exit $$s)\"\n"
+    },
+    {
+      "name": "postgres",
+      "image": "postgres:14-alpine",
+      "environment": {
+        "POSTGRES_DB": "planka",
+        "POSTGRES_HOST_AUTH_METHOD": "trust"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/planka/docker-compose.json
+++ b/apps/planka/docker-compose.json
@@ -8,11 +8,19 @@
       "internalPort": 1337,
       "environment": {
         "BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
-        "TRUST_PROXY": "1",
-        "DATABASE_URL": "\"postgresql://postgres@postgres/planka\"",
-        "SECRET_KEY": "\"${PLANKA_SECRET_KEY}\""
+        "TRUST_PROXY": 1,
+        "DATABASE_URL": "postgresql://postgres@planka-db/planka",
+        "SECRET_KEY": "${PLANKA_SECRET_KEY}",
+        "DEFAULT_ADMIN_EMAIL" : "${PLANKA_ADMIN_EMAIL}",
+        "DEFAULT_ADMIN_NAME": "${PLANKA_ADMIN_NAME}",
+        "DEFAULT_ADMIN_USERNAME": "${PLANKA_ADMIN_USERNAME}",
+        "DEFAULT_ADMIN_PASSWORD": "${PLANKA_ADMIN_PASSWORD}"
       },
-      "dependsOn": ["postgres"],
+      "dependsOn": {
+        "planka-db": {
+          "condition": "service_healthy"
+        }
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/user-avatars",
@@ -26,11 +34,10 @@
           "hostPath": "${APP_DATA_DIR}/data/attachments",
           "containerPath": "/app/private/attachments"
         }
-      ],
-      "command": "bash -c\n  \"for i in `seq 1 30`; do\n    ./start.sh &&\n    s=$$? && break || s=$$?;\n    echo \\\"Tried $$i times. Waiting 5 seconds...\\\";\n    sleep 5;\n  done; (exit $$s)\"\n"
+      ]
     },
     {
-      "name": "postgres",
+      "name": "planka-db",
       "image": "postgres:14-alpine",
       "environment": {
         "POSTGRES_DB": "planka",
@@ -41,7 +48,12 @@
           "hostPath": "${APP_DATA_DIR}/data/postgres",
           "containerPath": "/var/lib/postgresql/data"
         }
-      ]
+      ],
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "pg_isready -d planka -U postgres"
+      }
     }
   ]
 }

--- a/apps/planka/docker-compose.json
+++ b/apps/planka/docker-compose.json
@@ -11,7 +11,7 @@
         "TRUST_PROXY": 1,
         "DATABASE_URL": "postgresql://postgres@planka-db/planka",
         "SECRET_KEY": "${PLANKA_SECRET_KEY}",
-        "DEFAULT_ADMIN_EMAIL" : "${PLANKA_ADMIN_EMAIL}",
+        "DEFAULT_ADMIN_EMAIL": "${PLANKA_ADMIN_EMAIL}",
         "DEFAULT_ADMIN_NAME": "${PLANKA_ADMIN_NAME}",
         "DEFAULT_ADMIN_USERNAME": "${PLANKA_ADMIN_USERNAME}",
         "DEFAULT_ADMIN_PASSWORD": "${PLANKA_ADMIN_PASSWORD}"


### PR DESCRIPTION
## Dynamic compose for planka
This is a planka update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://planka.tipi.local (need to change BASE_URL if wanted)
- [x] https://planka.domain.com
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🌆 Uploading images (need HTTPS)
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/user-avatars:/app/public/user-avatars
- [x] ${APP_DATA_DIR}/data/project-background-images:/app/public/project-background-images
- [x] ${APP_DATA_DIR}/data/attachments:/app/private/attachments
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] ⌨ Command
- [x] 🔗 Depends on
- [x] 🩺 Healthcheck (newly added)

Other :
Added mandatory admin credentials in installation form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Planka
  - Introduced admin setup form with email, name, username, and password fields
  - Implemented Docker Compose configuration for Planka and PostgreSQL database

- **Chores**
  - Updated Tipi version from 44 to 45
  - Modified configuration timestamp
<!-- end of auto-generated comment: release notes by coderabbit.ai -->