### PR TITLE
Add dynamic compose for romm

### DIFF
--- a/apps/romm/config.json
+++ b/apps/romm/config.json
@@ -4,8 +4,9 @@
   "port": 8178,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "romm",
-  "tipi_version": 18,
+  "tipi_version": 19,
   "version": "3.7.2",
   "categories": ["gaming"],
   "description": "RomM (ROM Manager) allows you to scan, enrich, and browse your game collection with a clean and responsive interface. With support for multiple platforms, various naming schemes, and custom tags, RomM is a must-have for anyone who plays on emulators.",
@@ -60,5 +61,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736687749000
+  "updated_at": 1736983764244
 }

--- a/apps/romm/docker-compose.json
+++ b/apps/romm/docker-compose.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "romm",
+      "image": "ghcr.io/rommapp/romm:3.7.2",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "DB_HOST": "romm-db",
+        "DB_NAME": "romm",
+        "DB_USER": "tipi",
+        "DB_PASSWD": "${ROMM_MYSQL_PASSWORD}",
+        "ROMM_AUTH_SECRET_KEY": "${ROMM_AUTH_SECRET_KEY}",
+        "IGDB_CLIENT_ID": "${ROMM_IGDB_CLIENT_ID}",
+        "IGDB_CLIENT_SECRET": "${ROMM_IGDB_CLIENT_SECRET}",
+        "MOBYGAMES_API_KEY": "${ROMM_MOBYGAMES_API_KEY}",
+        "STEAMGRIDDB_API_KEY": "${ROMM_STEAMGRIDDB_API_KEY}"
+      },
+      "dependsOn": ["romm-db"],
+      "volumes": [
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/roms",
+          "containerPath": "/romm/library"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/redis-data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/romm-resources",
+          "containerPath": "/romm/resources"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/romm/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/assets",
+          "containerPath": "/romm/assets"
+        }
+      ]
+    },
+    {
+      "name": "romm-db",
+      "image": "lscr.io/linuxserver/mariadb:11.4.4",
+      "environment": {
+        "MYSQL_ROOT_PASSWORD": "${ROMM_MYSQL_ROOT_PASSWORD}",
+        "MYSQL_DATABASE": "romm",
+        "MYSQL_USER": "tipi",
+        "MYSQL_PASSWORD": "${ROMM_MYSQL_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for romm
This is a romm update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8178
- [x] https://romm.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x] 🌆 Uploading game
- [x] 🕹 Playing game (N64 OOT)
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${ROOT_FOLDER_HOST}/media/data/roms:/romm/library
- [x] ${APP_DATA_DIR}/data/redis:/redis-data
- [x] ${APP_DATA_DIR}/data/romm-resources:/romm/resources
- [x] ${APP_DATA_DIR}/data/config:/romm/config
- [x] ${APP_DATA_DIR}/data/assets:/romm/assets
- [x] ${APP_DATA_DIR}/data/mysql/config:/config
##### Specific instructions verified :
- [x] 🌳 Environment
- [x]  🔗 Depends on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Enabled dynamic configuration for the application
	- Updated Tipi version to 19
	- Updated configuration timestamp

- **Docker Configuration**
	- Added Docker Compose configuration for RomM application
	- Configured main service and database service with necessary environment variables and volume mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->