### PR TITLE
Add dynamic compose for plausible

### DIFF
--- a/apps/plausible/config.json
+++ b/apps/plausible/config.json
@@ -4,9 +4,10 @@
   "port": 8190,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "plausible",
   "deprecated": true,
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "v1.5.1",
   "categories": ["utilities"],
   "description": "Plausible Analytics is an easy to use, lightweight (< 1 KB), open source and privacy-friendly alternative to Google Analytics. It doesn’t use cookies and is fully compliant with GDPR, CCPA and PECR.",
@@ -36,5 +37,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724188518000
+  "updated_at": 1736983701753
 }

--- a/apps/plausible/docker-compose.json
+++ b/apps/plausible/docker-compose.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "plausible",
+      "image": "plausible/analytics:v1.5.1",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "SECRET_KEY_BASE": "${PLAUSIBLE_SECRET_KEY_BASE}",
+        "DATABASE_URL": "postgres://tipi:${PLAUSIBLE_DB_PASSWORD}@plausible-db:5432/plausible-db",
+        "CLICKHOUSE_DATABASE_URL": "http://plausible-events-db:8123/plausible_events_db",
+        "DISABLE_REGISTRATION": "${PLAUSIBLE_DISABLE_REGISTRATION}"
+      },
+      "dependsOn": ["plausible-db", "plausible-events-db"],
+      "command": "sh -c \"sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run\""
+    },
+    {
+      "name": "plausible-db",
+      "image": "postgres:14-alpine",
+      "environment": {
+        "POSTGRES_PASSWORD": "${PLAUSIBLE_DB_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "plausible-db"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/database/",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    },
+    {
+      "name": "plausible-events-db",
+      "image": "clickhouse/clickhouse-server:22.6-alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/plausible-event-data",
+          "containerPath": "/var/lib/clickhouse"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/clickhouse/clickhouse-config.xml",
+          "containerPath": "/etc/clickhouse-server/config.d/logging.xml",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/clickhouse/clickhouse-user-config.xml",
+          "containerPath": "/etc/clickhouse-server/users.d/logging.xml",
+          "readOnly": true
+        }
+      ],
+      "ulimits": {
+        "nofile": {
+          "soft": 262144,
+          "hard": 262144
+        }
+      }
+    }
+  ]
+}

--- a/apps/plausible/docker-compose.json
+++ b/apps/plausible/docker-compose.json
@@ -20,7 +20,7 @@
         "plausible-events-db": {
           "condition": "service_started"
         }
-      }
+      },
       "command": "sh -c \"sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run\""
     },
     {

--- a/apps/plausible/docker-compose.json
+++ b/apps/plausible/docker-compose.json
@@ -13,7 +13,14 @@
         "CLICKHOUSE_DATABASE_URL": "http://plausible-events-db:8123/plausible_events_db",
         "DISABLE_REGISTRATION": "${PLAUSIBLE_DISABLE_REGISTRATION}"
       },
-      "dependsOn": ["plausible-db", "plausible-events-db"],
+      "dependsOn": {
+        "plausible-db": {
+          "condition": "service_healthy"
+        },
+        "plausible-events-db": {
+          "condition": "service_started"
+        }
+      }
       "command": "sh -c \"sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run\""
     },
     {
@@ -29,7 +36,12 @@
           "hostPath": "${APP_DATA_DIR}/data/database/",
           "containerPath": "/var/lib/postgresql/data"
         }
-      ]
+      ],
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "pg_isready -d plausible-db -U tipi"
+      }
     },
     {
       "name": "plausible-events-db",
@@ -49,13 +61,7 @@
           "containerPath": "/etc/clickhouse-server/users.d/logging.xml",
           "readOnly": true
         }
-      ],
-      "ulimits": {
-        "nofile": {
-          "soft": 262144,
-          "hard": 262144
-        }
-      }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for plausible
This is a plausible update for using dynamic compose.
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://plausible.tipi.local
- [x] https://plausible.domain.com
##### In app tests :
- [x]  📝 Register and log in
- [x]  🌐 Add analytic link to a website
- [x]  📊 Check web traffic metrics
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/database/:/var/lib/postgresql/data
- [x]  ${APP_DATA_DIR}/data/plausible-event-data:/var/lib/clickhouse
- [x]  ${APP_DATA_DIR}/data/clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
- [x]  ${APP_DATA_DIR}/data/clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
##### Specific instructions :
- [x]  🌳 Environment
- [x]  ⌨ Command
- [x]  🔗 Depends on
- [x] 🩺 healthcheck (added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic configuration in Plausible.
  - Introduced Docker Compose configuration for Plausible analytics, including services for database management.

- **Chores**
  - Updated Plausible configuration version from 5 to 6.
  - Updated configuration timestamp to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->