### PR TITLE
Add dynamic compose for umami

### DIFF
--- a/apps/umami/config.json
+++ b/apps/umami/config.json
@@ -4,8 +4,9 @@
   "port": 8147,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "umami",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "v1.40.0",
   "categories": ["utilities"],
   "description": "Umami is a simple, fast, privacy-focused alternative to Google Analytics.",
@@ -28,5 +29,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983926617
 }

--- a/apps/umami/docker-compose.json
+++ b/apps/umami/docker-compose.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "umami",
+      "image": "ghcr.io/umami-software/umami:postgresql-v1.40.0",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "DATABASE_URL": "postgresql://umami:${DB_PASSWORD}@umami-db:5432/umami",
+        "DATABASE_TYPE": "postgresql",
+        "HASH_SALT": "${HASH_SALT}"
+      },
+      "dependsOn": ["umami-db"]
+    },
+    {
+      "name": "umami-db",
+      "image": "postgres:12-alpine",
+      "environment": {
+        "POSTGRES_DB": "umami",
+        "POSTGRES_USER": "umami",
+        "POSTGRES_PASSWORD": "${DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/umami/docker-compose.json
+++ b/apps/umami/docker-compose.json
@@ -11,7 +11,11 @@
         "DATABASE_TYPE": "postgresql",
         "HASH_SALT": "${HASH_SALT}"
       },
-      "dependsOn": ["umami-db"]
+      "dependsOn": {
+        "umami-db": {
+          "condition": "service_healthy"
+        }
+      }
     },
     {
       "name": "umami-db",
@@ -26,7 +30,12 @@
           "hostPath": "${APP_DATA_DIR}/data/postgres",
           "containerPath": "/var/lib/postgresql/data"
         }
-      ]
+      ],
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for umami
This is a umami update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8147
- [x] https://umami.tipi.lan
- [x] https://umami.domain.dom
##### In app tests :
- [x] 📝 Register and log in
- [x] 🔗 Create tracking link
- [x] 📊 Check stats
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🩺 Healthcheck (added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in Umami
	- Introduced Docker Compose configuration for Umami application with PostgreSQL backend

- **Configuration Updates**
	- Updated Umami configuration version
	- Updated application timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->