### PR TITLE
fix(lubelogger): connection string

### DIFF
--- a/apps/lubelogger/config.json
+++ b/apps/lubelogger/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "lubelogger",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "1.4.3",
   "dynamic_config": true,
   "categories": ["utilities"],

--- a/apps/lubelogger/docker-compose.json
+++ b/apps/lubelogger/docker-compose.json
@@ -45,7 +45,7 @@
         "LOGGING__LOGLEVEL__DEFAULT": "Error",
         "LC_ALL": "${LUBELOGGER_LOCALE:-en_US.UTF-8}",
         "LANG": "${LUBELOGGER_LOCALE:-en_US.UTF-8}",
-        "POSTGRES_CONNECTION": "Host='lubelogger-db:5432;Username=tipi;Password=tipi;Database=lubelogger;",
+        "POSTGRES_CONNECTION": "Host='lubelogger-db:5432';Username=tipi;Password=tipi;Database=lubelogger;",
         "EnableAuth": "${LUBELOGGER_ENABLE_AUTH:-false}",
         "UserNameHash": "${LUBELOGGER_USERNAME_HASH}",
         "UserPasswordHash": "${LUBELOGGER_PASSWORD_HASH}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated Tipi version from 13 to 14
	- Corrected PostgreSQL connection string syntax by removing unnecessary semicolon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->