### PR TITLE
Add dynamic compose for postfix-relay

### DIFF
--- a/apps/postfix-relay/config.json
+++ b/apps/postfix-relay/config.json
@@ -3,10 +3,11 @@
   "name": "Postfix Mail Relay",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 2525,
   "id": "postfix-relay",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "1.4.0",
   "categories": ["utilities"],
   "description": "Simple SMTP relay for environments where you may have private servers with no Internet connection.",
@@ -70,5 +71,5 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192
+  "updated_at": 1736983708915
 }

--- a/apps/postfix-relay/docker-compose.json
+++ b/apps/postfix-relay/docker-compose.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "postfix-relay",
+      "image": "simenduev/postfix-relay:1.4.0",
+      "isMain": true,
+      "internalPort": 25,
+      "environment": {
+        "ACCEPTED_NETWORKS": "${RELAY_ACCEPTED_NETWORKS}",
+        "SMTP_HOST": "${RELAY_SMTP_HOST}",
+        "SMTP_LOGIN": "${RELAY_SMTP_LOGIN}",
+        "SMTP_PASSWORD": "${RELAY_SMTP_PASSWORD}",
+        "SMTP_PORT": "${RELAY_SMTP_PORT}",
+        "TLS_VERIFY": "${RELAY_TLS_VERIFY}",
+        "USE_TLS": "${RELAY_USE_TLS}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/root/config"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "netstat -an | grep 25 > /dev/null; if [ 0 != $? ]; then exit 1; fi;"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for postfix-relay
This is a postfix-relay update for using dynamic compose.
##### Reaching the app :
- [x] SMTP Port (25)
##### In app tests :
- [x]  📝 Register SMTP
- [x]  ⚙ Setup postfix for apps SMTP
- [x]  📧 Send mail
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/config:/root/config:rw
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Postfix Mail Relay
  - Introduced new Docker Compose configuration for Postfix Relay service

- **Configuration Updates**
  - Updated Tipi version from 2 to 3
  - Modified configuration timestamp

- **Service Deployment**
  - Deployed Postfix Relay service with version 1.4.0
  - Configured SMTP settings and health checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->