### PR TITLE
Add dynamic compose for sshwifty

### DIFF
--- a/apps/sshwifty/config.json
+++ b/apps/sshwifty/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "sshwifty",
-  "tipi_version": 20,
+  "tipi_version": 21,
   "version": "0.3.16-beta-release",
   "categories": ["development"],
   "description": "Sshwifty is a SSH and Telnet connector made for the Web. It can be deployed on your computer or server to provide SSH and Telnet access interface for any compatible (standard) web browser.",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1737289658000
+  "updated_at": 1737296507326
 }

--- a/apps/sshwifty/docker-compose.json
+++ b/apps/sshwifty/docker-compose.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "sshwifty",
+      "image": "niruix/sshwifty:0.3.16-beta-release",
+      "isMain": true,
+      "internalPort": 8182,
+      "privileged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for sshwifty
This is a sshwifty update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x]  https://sshwifty.tipi.local
##### In app tests :
- [x] 🐚 Establish a SSH connection
##### Specific instructions :
- [x]  👑 Privileged