### PR TITLE
Add dynamic compose for resilio-sync

### DIFF
--- a/apps/resilio-sync/config.json
+++ b/apps/resilio-sync/config.json
@@ -4,7 +4,7 @@
   "port": 8113,
   "available": true,
   "id": "resilio-sync",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "3.0.0",
   "uid": 1000,
   "gid": 1000,
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724439921000
+  "updated_at": 1736983749682
 }

--- a/apps/resilio-sync/docker-compose.json
+++ b/apps/resilio-sync/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "resilio-sync",
+      "image": "lscr.io/linuxserver/resilio-sync:3.0.0",
+      "isMain": true,
+      "internalPort": 8888,
+      "addPorts": [
+        {
+          "hostPort": 55555,
+          "containerPort": 55555
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/downloads",
+          "containerPath": "/downloads"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/sync",
+          "containerPath": "/sync"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for resilio-sync
This is a resilio-sync update for using dynamic compose.
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://resilio-sync.tipi.local
- [x] 🌐 Additionnal Port (5555)
##### In app tests :
- [x] 📝 Register licence and log in
- [x] 📂 Add synced folder
- [x] 📱 Link another peer
- [x] 🔃 Sync files in both ways
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/config:/config
- [x]  ${APP_DATA_DIR}/data/downloads:/downloads
- [x]  ${APP_DATA_DIR}/data/sync:/sync
##### Specific instructions :
- [x]  🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docker Compose configuration for Resilio Sync application
  - Deployed Resilio Sync version 3.0.0

- **Chores**
  - Updated application configuration version from 5 to 6
  - Updated timestamp for configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->