### PR TITLE
Add dynamic compose for slskd

### DIFF
--- a/apps/slskd/config.json
+++ b/apps/slskd/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 5030,
   "exposable": true,
+  "dynamic_config": true,
   "id": "slskd",
   "description": "A modern client-server application for the Soulseek file-sharing network.",
-  "tipi_version": 9,
+  "tipi_version": 10,
   "version": "0.22.1",
   "categories": ["utilities"],
   "short_desc": "P2P downloads",
@@ -53,6 +54,6 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1734481140000,
+  "updated_at": 1736983827927,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/slskd/docker-compose.json
+++ b/apps/slskd/docker-compose.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "slskd",
+      "image": "slskd/slskd:0.22.1",
+      "isMain": true,
+      "internalPort": 5030,
+      "environment": {
+        "SLSKD_WEB_USER": "${SLSKD_WEB_USER}",
+        "SLSKD_WEB_PASSWORD": "${SLSKD_WEB_PASSWORD}",
+        "SLSKD_USER": "${SLSKD_USER}",
+        "SLSKD_PASSWORD": "${SLSKD_PASSWORD}",
+        "SLSKD_REMOTE_CONFIGURATION": "${SLSKD_REMOTE_CONFIGURATION}",
+        "SLSKD_CONFIG": "/app/data/slskd.yml",
+        "SLSKD_SHARED_DIR": "/shared"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}",
+          "containerPath": "/app"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/downloads/complete",
+          "containerPath": "/downloads"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/downloads/incomplete",
+          "containerPath": "/incomplete"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/",
+          "containerPath": "/shared"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for slskd
This is a slskd update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://slskd.tipi.local
##### In app tests :
- [x] 📝 Register and log in
- [x] 💬 Join conversations
- [x] 🔎 Search and download files
- [x] 👓 Check received data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}:/app
- [x]  ${ROOT_FOLDER_HOST}/media/downloads/complete:/downloads
- [x]  ${ROOT_FOLDER_HOST}/media/downloads/incomplete:/incomplete
- [x]  ${ROOT_FOLDER_HOST}/media/:/shared
##### Specific instructions :
- [x]  🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support
	- Updated Tipi version to 10
	- Modified configuration timestamp

- **Service Configuration**
	- Introduced new Docker Compose configuration for slskd service
	- Defined service ports, environment variables, and volume mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->