### PR TITLE
Add dynamic compose for speedtest tracker

### DIFF
--- a/apps/speedtest-tracker/config.json
+++ b/apps/speedtest-tracker/config.json
@@ -4,8 +4,9 @@
   "port": 8211,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "speedtest-tracker",
-  "tipi_version": 56,
+  "tipi_version": 57,
   "version": "1.1.0",
   "categories": ["utilities"],
   "description": "Speedtest Tracker is a self-hosted internet performance tracking application that runs speedtest checks against Ookla's Speedtest service.",
@@ -50,5 +51,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736837637000
+  "updated_at": 1736983842510
 }

--- a/apps/speedtest-tracker/docker-compose.json
+++ b/apps/speedtest-tracker/docker-compose.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "speedtest-tracker",
+      "image": "lscr.io/linuxserver/speedtest-tracker:1.1.0",
+      "isMain": true,
+      "internalPort": 80,
+      "addPorts": [
+        {
+          "hostPort": 8212,
+          "containerPort": 443
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "DB_CONNECTION": "pgsql",
+        "DB_HOST": "speedtest-tracker-db",
+        "DB_PORT": "5432",
+        "DB_DATABASE": "speedtest-tracker",
+        "DB_USERNAME": "tipi",
+        "DB_PASSWORD": "${SPEEDTEST_TRACKER_DB_PASSWORD}",
+        "SPEEDTEST_SCHEDULE": "${SPEEDTEST_SCHEDULE:-'30 * * * *'}",
+        "SPEEDTEST_SERVERS": "${SPEEDTEST_SERVERS:-''}",
+        "TZ": "${TZ}",
+        "APP_TIMEZONE": "${TZ}",
+        "DISPLAY_TIMEZONE": "${TZ}",
+        "APP_KEY": "${SPEEDTEST_APP_KEY}"
+      },
+      "dependsOn": ["speedtest-tracker-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/speedtest-tracker/config",
+          "containerPath": "/config"
+        }
+      ]
+    },
+    {
+      "name": "speedtest-tracker-db",
+      "image": "postgres:15",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${SPEEDTEST_TRACKER_DB_PASSWORD}",
+        "POSTGRES_DB": "speedtest-tracker"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/speedtest-tracker/docker-compose.json
+++ b/apps/speedtest-tracker/docker-compose.json
@@ -6,12 +6,6 @@
       "image": "lscr.io/linuxserver/speedtest-tracker:1.1.0",
       "isMain": true,
       "internalPort": 80,
-      "addPorts": [
-        {
-          "hostPort": 8212,
-          "containerPort": 443
-        }
-      ],
       "environment": {
         "PUID": "1000",
         "PGID": "1000",
@@ -49,7 +43,12 @@
           "hostPath": "${APP_DATA_DIR}/data/postgres",
           "containerPath": "/var/lib/postgresql/data"
         }
-      ]
+      ],
+      "healthCheck": {
+        "timeout": "5s",
+        "retries": 3,
+        "test": "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for speedtest-tracker
This is a speedtest-tracker update for using dynamic compose. 
##### Reaching the app :
- [x] http://localip:8211
- [x] https://speedtest-tracker.tipi.lan
- Additionnals ports (removed)
##### In app tests :
- [x] 📝 Register and create entries
- [x] 🌆 Do multiple speedtests
- [x] 📊 Check stats
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/speedtest-tracker/config:/config
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic configuration in Speedtest Tracker
  - Introduced Docker Compose configuration for Speedtest Tracker application

- **Chores**
  - Updated application version
  - Configured database and application services for containerized deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->