### PR TITLE
Add dynamic compose for ghost-dev

### DIFF
--- a/apps/ghost-dev/config.json
+++ b/apps/ghost-dev/config.json
@@ -4,8 +4,9 @@
   "port": 8225,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "ghost-dev",
-  "tipi_version": 40,
+  "tipi_version": 41,
   "version": "5.106.1",
   "categories": ["social", "media"],
   "description": "Ghost is a powerful app for new-media creators to publish, share, and grow a business around their content. It comes with modern tools to build a website, publish content, send newsletters & offer paid subscriptions to members.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736818189000
+  "updated_at": 1736983431730
 }

--- a/apps/ghost-dev/docker-compose.json
+++ b/apps/ghost-dev/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "ghost-dev",
+      "image": "ghost:5.106.1",
+      "isMain": true,
+      "internalPort": 2368,
+      "environment": {
+        "database__connection__filename": "/var/lib/ghost/content/data/ghost.db",
+        "NODE_ENV": "development"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/var/lib/ghost/content"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for ghost-dev
This is a ghost-dev update for using dynamic compose. (no other change)
##### Reaching the app :
- [x] http://localip:8225
- [x] https://ghost-dev.tipi.lan
##### In app tests :
- [x]  🖱 Basic interaction
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/var/lib/ghost/content
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Enabled dynamic configuration
	- Updated Tipi version to 41
	- Updated configuration timestamp

- **New Features**
	- Added Docker Compose configuration for Ghost development service
	- Configured persistent data storage for Ghost application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->