### PR TITLE
Add dynamic compose for kiwix-serve

### DIFF
--- a/apps/kiwix-serve/config.json
+++ b/apps/kiwix-serve/config.json
@@ -4,8 +4,9 @@
   "port": 8169,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "kiwix-serve",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "3.7.0-2",
   "categories": ["media"],
   "description": "Kiwix Server is a web server for hosting .zim files",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736983509966
 }

--- a/apps/kiwix-serve/docker-compose.json
+++ b/apps/kiwix-serve/docker-compose.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "kiwix-serve",
+      "image": "ghcr.io/kiwix/kiwix-serve:3.7.0-2",
+      "isMain": true,
+      "internalPort": 8080,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/zim",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "*.zim"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for kiwix-serve
This is a kiwix-serve update for using dynamic compose. (no other change)
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:port
  - [x] https://kiwix-serve.tipi.lan
##### In app tests :
- [x] 🌆 add zim files inside data directory
- [x] 🖱 Interact with website
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/zim:/data
##### Specific instructions verified :
- [x] 💻 Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration support for Kiwix Server
	- Introduced new Docker Compose configuration for Kiwix service

- **Chores**
	- Updated Kiwix Server configuration version
	- Updated service timestamp
	- Configured Kiwix service to use Docker image version 3.7.0-2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->