### PR TITLE
Add dynamic compose for invidious

### DIFF
--- a/apps/invidious/config.json
+++ b/apps/invidious/config.json
@@ -3,10 +3,11 @@
   "name": "Invidious",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8095,
   "id": "invidious",
   "version": "master",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "categories": ["media", "social"],
   "description": "Invidious is an open source alternative front-end to YouTube.",
   "short_desc": "An alternative front-end to YouTube",
@@ -62,5 +63,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736983480556
 }

--- a/apps/invidious/docker-compose.json
+++ b/apps/invidious/docker-compose.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "invidious",
+      "image": "quay.io/invidious/invidious:master",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "INVIDIOUS_CONFIG": "db:\n  dbname: invidious\n  user: tipi\n  password: tipi\n  host: invidious-db\n  port: 5432\ncheck_tables: true\nhmac_key: ${INVIDIOUS_HMAC_KEY}\nuse_innertube_for_captions: true\ndomain: ${INVIDIOUS_DOMAIN}\nexternal_port: ${INVIDIOUS_EXTERNAL_PORT:-${APP_PORT}}\nhttps_only: ${INVIDIOUS_HTTPS_ONLY}\nsignature_server: inv_sig_helper:12999\nvisitor_data: ${INVIDIOUS_VISITOR_DATA}\npo_token: ${INVIDIOUS_PO_TOKEN}\n"
+      },
+      "dependsOn": {
+        "invidious-db": {
+          "condition": "service_healthy"
+        },
+        "inv_sig_helper": {
+          "condition": "service_started"
+        }
+      },
+      "healthCheck": {
+        "interval": "30s",
+        "timeout": "5s",
+        "retries": 2,
+        "test": "wget -nv --tries=1 --spider http://127.0.0.1:3000/api/v1/trending || exit 1"
+      }
+    },
+    {
+      "name": "inv_sig_helper",
+      "image": "quay.io/invidious/inv-sig-helper:latest",
+      "environment": {
+        "RUST_LOG": "info"
+      },
+      "readOnly": true,
+      "command": ["--tcp", "0.0.0.0:12999"],
+      "capDrop": ["ALL"],
+      "securityOpt": ["no-new-privileges:true"]
+    },
+    {
+      "name": "invidious-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_DB": "invidious",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "tipi"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/init/sql",
+          "containerPath": "/config/sql"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/init/init-invidious-db.sh",
+          "containerPath": "/docker-entrypoint-initdb.d/init-invidious-db.sh"
+        }
+      ],
+      "healthCheck": {
+        "test": "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for invidious
This is a invidious update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://invidious.tipi.local
##### In app tests :
- [x]  📝 Register and log in
- [x] 🔍 Search videos and channels
- [x] 🎞 Watch a video
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/init/sql:/config/sql
- [x] ${APP_DATA_DIR}/data/init/init-invidious-db.sh:/docker-entrypoint-initdb.d/init-invidious-db.sh
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck
- [x] 🔗 Depends on
- [x] ⌨ Command
- [x] ▶ Read only
- [x] 🔒 Capacity drop
- [x] 🔐 Security options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support for Invidious
	- Updated Tipi version to 14
	- Updated configuration timestamp

- **Infrastructure**
	- Introduced new Docker Compose configuration for Invidious
	- Configured services for Invidious application, database, and signature helper
	- Added health checks and dependency management for services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->