### PR TITLE
Add dynamic compose for syncthing

### DIFF
--- a/apps/syncthing/config.json
+++ b/apps/syncthing/config.json
@@ -3,9 +3,10 @@
   "name": "Syncthing",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8090,
   "id": "syncthing",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "1.29",
   "categories": ["data", "utilities"],
   "description": "Syncthing is a continuous file synchronization program. It synchronizes files between two or more computers. We strive to fulfill the goals below. The goals are listed in order of importance, the most important one being the first. This is the summary version of the goal list - for more commentary, see the full Goals document.",
@@ -25,5 +26,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736159302000
+  "updated_at": 1736983871915
 }

--- a/apps/syncthing/docker-compose.json
+++ b/apps/syncthing/docker-compose.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "syncthing",
+      "image": "syncthing/syncthing:1.29",
+      "isMain": true,
+      "internalPort": 8384,
+      "addPorts": [
+        {
+          "hostPort": 22000,
+          "containerPort": 22000,
+          "tcp": true,
+          "udp": true
+        },
+        {
+          "hostPort": 21027,
+          "containerPort": 21027,
+          "udp": true
+        }
+      ],
+      "hostname": "${SYNCTHING_HOSTNAME:-tipi}",
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/var/syncthing"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/syncthing",
+          "containerPath": "/media/data/syncthing"
+        }
+      ],
+      "stopGracePeriod": "1m"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for syncthing
This is a syncthing update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://syncthing.tipi.local
- [x] 🌐 Additionnal Port(s)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🤝 Create share
- [x] 📱 Add new peer
- [x] 🌆 Add files to share
- [x] 🔁 Check synced data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data:/var/syncthing
- [x] ${ROOT_FOLDER_HOST}/media/data/syncthing:/media/data/syncthing
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🖥 Hostname
- [x] 👼 Stop grace period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support
	- Updated Tipi version to 15
	- Updated configuration timestamp

- **Service Configuration**
	- Added Docker Compose configuration for Syncthing
	- Configured service with version 1.29
	- Set up port mappings and volume mounts
	- Defined environment variables for user and group IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->