### PR TITLE
Add dynamic compose for odoo

### DIFF
--- a/apps/odoo/config.json
+++ b/apps/odoo/config.json
@@ -3,8 +3,9 @@
   "port": 8017,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "odoo",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "18",
   "categories": ["utilities", "finance"],
   "description": "Open-source business management software suite designed to streamline various aspects of business operations. With its modular structure, users can choose and integrate specific applications such as accounting, inventory, and sales. Odoo provides a user-friendly interface, scalability for businesses of all sizes, and is available in both community (free) and enterprise editions. Its integrated approach and customization options make it a popular choice for comprehensive ERP (Enterprise Resource Planning) solutions.",
@@ -21,6 +22,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731514116000,
+  "updated_at": 1736983636492,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/odoo/docker-compose.json
+++ b/apps/odoo/docker-compose.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "odoodb",
+      "image": "postgres:15",
+      "user": "root",
+      "environment": {
+        "POSTGRES_USER": "odoo",
+        "POSTGRES_PASSWORD": "${ODOO_POSTGRES_PASSWORD}",
+        "POSTGRES_DB": "postgres"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgresql",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    },
+    {
+      "name": "odoo",
+      "image": "odoo:18",
+      "isMain": true,
+      "internalPort": 8069,
+      "user": "root",
+      "environment": {
+        "HOST": "odoodb",
+        "USER": "odoo",
+        "PASSWORD": "${ODOO_POSTGRES_PASSWORD}"
+      },
+      "dependsOn": ["odoodb"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/addons",
+          "containerPath": "/mnt/extra-addons"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/etc",
+          "containerPath": "/etc/odoo"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/odoo-web-data",
+          "containerPath": "/var/lib/odoo"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/filestore",
+          "containerPath": "/root/.local/share"
+        }
+      ],
+      "command": "--",
+      "tty": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for odoo
This is a odoo update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://odoo.tipi.local
##### In app tests :
- [x]  📝 Register and create database
- [x] ⌨ Choose an app to activate
- [x] 🖱 Basic interaction
- [x] 🧮 Create entries
- [x] 🌆 Uploading images
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/postgresql:/var/lib/postgresql/data
- [x]  ${APP_DATA_DIR}/data/addons:/mnt/extra-addons
- [x]  ${APP_DATA_DIR}/data/etc:/etc/odoo
- [x]  ${APP_DATA_DIR}/data/odoo-web-data:/var/lib/odoo
- [x]  ${APP_DATA_DIR}/data/filestore:/root/.local/share
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (root)
- [x]  ⌨ Command
- [x]  🔗 Depends on
- [x]  🔤 TTY