### PR TITLE
Add dynamic compose for firefly-iii

### DIFF
--- a/apps/firefly-iii/config.json
+++ b/apps/firefly-iii/config.json
@@ -3,8 +3,9 @@
   "name": "Firefly III",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8115,
-  "tipi_version": 7,
+  "tipi_version": 8,
   "version": "version-6.1.21",
   "id": "firefly-iii",
   "categories": ["finance"],
@@ -44,5 +45,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983403097
 }

--- a/apps/firefly-iii/docker-compose.json
+++ b/apps/firefly-iii/docker-compose.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "firefly-iii",
+      "image": "fireflyiii/core:version-6.1.21",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "APP_ENV": "local",
+        "APP_DEBUG": "false",
+        "SITE_OWNER": "${EMAIL}",
+        "APP_KEY": "${APP_KEY}",
+        "STATIC_CRON_TOKEN": "${STATIC_CRON_TOKEN}",
+        "TZ": "${TZ}",
+        "TRUSTED_PROXIES": "**",
+        "DB_CONNECTION": "mysql",
+        "DB_HOST": "firefly-iii-db",
+        "DB_PORT": "3306",
+        "DB_DATABASE": "firefly",
+        "DB_USERNAME": "firefly",
+        "DB_PASSWORD": "${MYSQL_PASSWORD}",
+        "COOKIE_PATH": "\"/\"",
+        "COOKIE_DOMAIN": "",
+        "COOKIE_SECURE": "false",
+        "COOKIE_SAMESITE": "lax",
+        "APP_NAME": "FireflyIII",
+        "BROADCAST_DRIVER": "log",
+        "QUEUE_DRIVER": "sync",
+        "CACHE_PREFIX": "firefly",
+        "IS_HEROKU": "false",
+        "FIREFLY_III_LAYOUT": "v1",
+        "APP_URL": "http://localhost:${APP_PORT}"
+      },
+      "dependsOn": ["firefly-iii-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/uplodad",
+          "containerPath": "/var/www/html/storage/upload"
+        }
+      ]
+    },
+    {
+      "name": "firefly-iii-db",
+      "image": "mariadb",
+      "hostname": "fireflyiii-db",
+      "environment": {
+        "MYSQL_RANDOM_ROOT_PASSWORD": "yes",
+        "MYSQL_USER": "firefly",
+        "MYSQL_PASSWORD": "${MYSQL_PASSWORD}",
+        "MYSQL_DATABASE": "firefly"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/mysql"
+        }
+      ]
+    },
+    {
+      "name": "firefly-iii-cron",
+      "image": "alpine",
+      "command": "sh -c \"echo \\\"0 3 * * * wget -qO- http://${APP_DOMAIN}/api/v1/cron/${STATIC_CRON_TOKEN}\\\" | crontab - && crond -f -L /dev/stdout\""
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for firefly-iii
This is a firefly-iii update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:8115
- [x] https://firefly-iii.tipi.lan
##### In app tests :
- [x]  📝 Register and log in
- [x]  🖱 Basic interaction
- [x] 🗝 Create Access token for importer
- [x] 📊 Check received data from importer
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/uplodad:/var/www/html/storage/upload (yes "uplodad" 🤡)
- [x]  ${APP_DATA_DIR}/data/db:/var/lib/mysql
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  🖥 Hostname
- [x]  ⌨ Command