### PR TITLE
Add dynamic compose for firefly-iii-data-importer

### DIFF
--- a/apps/firefly-iii-data-importer/config.json
+++ b/apps/firefly-iii-data-importer/config.json
@@ -3,8 +3,9 @@
   "name": "Firefly III Data Importer",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8150,
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "version-1.5.6",
   "id": "firefly-iii-data-importer",
   "categories": ["finance"],
@@ -35,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736983409610
 }

--- a/apps/firefly-iii-data-importer/docker-compose.json
+++ b/apps/firefly-iii-data-importer/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "firefly-iii-data-importer",
+      "image": "fireflyiii/data-importer:version-1.5.6",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "FIREFLY_III_URL": "${FIREFLY_III_URL}",
+        "FIREFLY_III_ACCESS_TOKEN": "${FIREFLY_III_ACCESS_TOKEN}",
+        "FIREFLY_III_CLIENT_ID": "${FIREFLY_III_CLIENT_ID}",
+        "TZ": "${TZ}",
+        "TRUSTED_PROXIES": "**",
+        "VERIFY_TLS_SECURITY": "false",
+        "APP_ENV": "local",
+        "APP_DEBUG": "false",
+        "LOG_CHANNEL": "stack",
+        "LOG_LEVEL": "info"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for firefly-iii-data-importer
This is a firefly-iii-data-importer update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://firefly-iii-data-importer.tipi.local
##### In app tests :
- [x]  📝 Register access key
- [x]  📁 Import CSV file and set matching columns
- [x] 💱 Send transactions to Firefly III successfully
##### Specific instructions :
- [x]  🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support for Firefly III Data Importer
	- Updated Tipi version from 5 to 6
	- Updated configuration timestamp

- **New Features**
	- Introduced Docker Compose configuration for Firefly III Data Importer
	- Configured service with version 1.5.6 Docker image
	- Set up environment variables and service settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->