### PR TITLE
Add dynamic compose for seedsync

### DIFF
--- a/apps/seedsync/config.json
+++ b/apps/seedsync/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "port": 8800,
   "exposable": true,
+  "dynamic_config": true,
   "id": "seedsync",
   "description": "SeedSync is a tool to sync the files on a remote Linux server (like your seedbox, for example). It uses LFTP to transfer files fast!",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "0.8.6",
   "categories": ["utilities"],
   "short_desc": "SeedSync is a tool to sync the files on a remote Linux server.",
@@ -31,5 +32,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192
+  "updated_at": 1736983794159
 }

--- a/apps/seedsync/docker-compose.json
+++ b/apps/seedsync/docker-compose.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "seedsync",
+      "image": "ipsingh06/seedsync:0.8.6",
+      "isMain": true,
+      "internalPort": 8800,
+      "user": "${SEEDSYNC_PUID:-1000}:${SEEDSYNC_PGID:-1000}",
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents/complete",
+          "containerPath": "/downloads"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for seedsync
This is a seedsync update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://seedsync.tipi.local
##### In app tests :
- [x] 📝 Set remote configuration
- [x] 🅰 Restart app
- [x] 🍃 Check synchronized files
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/config:/config
- [x]  ${ROOT_FOLDER_HOST}/media/torrents/complete:/downloads
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (${SEEDSYNC_PUID:-1000}:${SEEDSYNC_PGID:-1000})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for dynamic configuration in the SeedSync application
	- Updated application version to 3
	- Introduced Docker Compose configuration for SeedSync service

- **Configuration Changes**
	- Updated configuration timestamp
	- Configured Docker service with persistent storage and environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->