### PR TITLE
Add dynamic compose for email-oauth2-proxy

### DIFF
--- a/apps/email-oauth2-proxy/config.json
+++ b/apps/email-oauth2-proxy/config.json
@@ -3,10 +3,11 @@
   "name": "Email OAuth2 Proxy",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 1999,
   "id": "email-oauth2-proxy",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "2024.11.19",
   "categories": ["utilities", "security"],
   "description": "Transparently add OAuth 2.0 support to IMAP/POP/SMTP client applications, scripts or any other email use-cases that don't support this authentication method.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1732048304000
+  "updated_at": 1736983377069
 }

--- a/apps/email-oauth2-proxy/docker-compose.json
+++ b/apps/email-oauth2-proxy/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "email-oauth2-proxy",
+      "image": "ghcr.io/blacktirion/email-oauth2-proxy-docker:2024.11.19",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "DEBUG": "true",
+        "CACHE_STORE": "/config/credstore.config",
+        "LOGFILE": "true",
+        "LOCAL_SERVER_AUTH": "true"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for email-oauth2-proxy
This is a email-oauth2-proxy update for using dynamic compose.
##### In app tests :
- [x] 📝 Create config files and add OAuth ID
- [x] 🌆 Send mail from another app
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/config:/config:rw
##### Specific instructions verified :
- [x] 🌳 Environment