### PR TITLE
Add dynamic compose for mylar3

### DIFF
--- a/apps/mylar3/config.json
+++ b/apps/mylar3/config.json
@@ -4,8 +4,9 @@
   "port": 8174,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "mylar3",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "v0.7.1-ls84",
   "categories": ["media"],
   "description": "Mylar3 is an automated Comic Book downloader (cbr/cbz) for use with NZB and torrents written in python.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736983593616
 }

--- a/apps/mylar3/docker-compose.json
+++ b/apps/mylar3/docker-compose.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "mylar3",
+      "image": "lscr.io/linuxserver/mylar3:v0.7.1-ls84",
+      "isMain": true,
+      "internalPort": 8090,
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mylar3-config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/comics",
+          "containerPath": "/comics"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/downloads/mylar3",
+          "containerPath": "/downloads"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for mylar3
This is a mylar3 update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://mylar3.tipi.local
##### In app tests :
- [x] 📝 Add configuration information
- [x] 🔎 Search a comic
- [x] 📚 Uploading data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/mylar3-config:/config
- [x]  ${ROOT_FOLDER_HOST}/media/data/comics:/comics
- [x]  ${ROOT_FOLDER_HOST}/media/downloads/mylar3:/downloads
##### Specific instructions :
- [x]  🌳 Environment