### PR TITLE
Add dynamic compose for proxitok

### DIFF
--- a/apps/proxitok/config.json
+++ b/apps/proxitok/config.json
@@ -3,11 +3,12 @@
   "name": "ProxiTok",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8118,
   "id": "proxitok",
   "categories": ["social"],
   "description": "",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "master",
   "short_desc": "Open source alternative frontend for TikTok made using PHP ",
   "author": "pablouser1",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736983716327
 }

--- a/apps/proxitok/docker-compose.json
+++ b/apps/proxitok/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "proxitok",
+      "image": "ghcr.io/pablouser1/proxitok:master",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "LATTE_CACHE": "/cache",
+        "API_CACHE": "redis",
+        "REDIS_HOST": "proxitok-redis",
+        "REDIS_PORT": "6379",
+        "API_SIGNER": "remote",
+        "API_SIGNER_URL": "http://proxitok-signer:8080/signature"
+      },
+      "dependsOn": ["proxitok-redis", "proxitok-signer"],
+      "volumes": [
+        {
+          "hostPath": "proxitok-cache",
+          "containerPath": "/cache"
+        }
+      ]
+    },
+    {
+      "name": "proxitok-redis",
+      "image": "redis:7-alpine",
+      "command": "redis-server --save 60 1 --loglevel warning"
+    },
+    {
+      "name": "proxitok-signer",
+      "image": "ghcr.io/pablouser1/signtok:master"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for proxitok
This is a proxitok update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [ ] https://proxitok.tipi.local (same as before)
##### In app tests :
- [x]  📝 Access search menu
- Tiktok scrapper broken (can't go further)
##### Volumes mapping :
- [x] proxitok-cache:/cache
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  ⌨ Command