### PR TITLE
nextgba: fix image path

### DIFF
--- a/apps/nextgba/docker-compose.json
+++ b/apps/nextgba/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "nextgba",
-      "image": "ghcr.io/meienberger/nextgba:v0.1.0",
+      "image": "ghcr.io/nicotsx/nextgba:v0.1.0",
       "isMain": true,
       "internalPort": 3000,
       "environment": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker image reference for the NextGBA service from `ghcr.io/meienberger/nextgba:v0.1.0` to `ghcr.io/nicotsx/nextgba:v0.1.0`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->