### PR TITLE
Add dynamic compose for homeassistant (unexposed)

### DIFF
--- a/apps/homeassistant/config.json
+++ b/apps/homeassistant/config.json
@@ -4,7 +4,7 @@
   "available": true,
   "deprecated": true,
   "port": 8123,
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "stable",
   "id": "homeassistant",
   "categories": ["automation"],
@@ -15,5 +15,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983452653
 }

--- a/apps/homeassistant/config.json
+++ b/apps/homeassistant/config.json
@@ -3,6 +3,7 @@
   "name": "Home Assistant non exposed",
   "available": true,
   "deprecated": true,
+  "dynamic_config": true,
   "port": 8123,
   "tipi_version": 4,
   "version": "stable",

--- a/apps/homeassistant/docker-compose.json
+++ b/apps/homeassistant/docker-compose.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "homeassistant",
+      "image": "ghcr.io/home-assistant/home-assistant:stable",
+      "isMain": true,
+      "networkMode": "host",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/config",
+          "containerPath": "/config"
+        }
+      ],
+      "privileged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for homeassistant (deprecated)
This is a homeassistant update for using dynamic compose. (no other change)
##### Situation tested :
- 💾 Update on existing data
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:
- [ ] https://homeassistant.tipi.lan (same as before)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🎛 Add integrations
- [x] 💡 Create automations
- [x] 🌆 Uploading data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/config:/config
##### ##### Specific instructions :
- [x] 🌐 Network mode (host)
- [x] 👑 Privileged