### PR TITLE
Add dynamic compose for write-freely

### DIFF
--- a/apps/write-freely/config.json
+++ b/apps/write-freely/config.json
@@ -3,9 +3,10 @@
   "name": "Write-Freely",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8574,
   "id": "write-freely",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "0.15",
   "categories": ["social"],
   "description": "A clean, Markdown-based publishing platform made for writers. Write together and build a community.",
@@ -15,5 +16,5 @@
   "website": "https://writefreely.org/",
   "supported_architectures": ["amd64", "arm64"],
   "created_at": 1729978316000,
-  "updated_at": 1729978316000
+  "updated_at": 1736983956310
 }

--- a/apps/write-freely/docker-compose.json
+++ b/apps/write-freely/docker-compose.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "write-freely",
+      "image": "nephatrine/write-freely:0.15",
+      "isMain": true,
+      "internalPort": 8080,
+      "addPorts": [
+        {
+          "hostPort": 70,
+          "containerPort": 70,
+          "tcp": true
+        }
+      ],
+      "environment": {
+        "TZ": "${TZ}",
+        "PUID": 1000,
+        "PGID": 1000
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/mnt/config"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for write-freely
This is a write-freely update for using dynamic compose.
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8137
- [x] https://write-freely.tipi.lan
- [x] Additionnal port (70)
##### In app tests :
- [x] 📝 Create user from CLI and log in
- [x] ✍️ Write a post
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Added dynamic configuration support for Write-Freely app
  - Updated application version from 3 to 4
  - Modified configuration timestamp

- **New Features**
  - Introduced Docker Compose configuration for Write-Freely service
  - Added port mapping and environment variable settings for the service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->