### PR TITLE
Add dynamic compose for matter-server

### DIFF
--- a/apps/matter-server/config.json
+++ b/apps/matter-server/config.json
@@ -3,10 +3,11 @@
   "name": "Matter Server",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 9997,
   "id": "matter-server",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "7.0.1",
   "categories": ["utilities", "automation"],
   "author": "OpenHomeFoundation",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736110091000
+  "updated_at": 1736983558771
 }

--- a/apps/matter-server/docker-compose.json
+++ b/apps/matter-server/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "matter-server",
+      "image": "ghcr.io/home-assistant-libs/python-matter-server:7.0.1",
+      "isMain": true,
+      "networkMode": "host",
+      "volumes": [
+        {
+          "hostPath": "/run/dbus",
+          "containerPath": "/run/dbus",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ],
+      "securityOpt": ["apparmor=unconfined"]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for matter-server
This is a matter-server update for using dynamic compose.
##### In app tests :
- [x] 📝 Connect to Home Assistant
##### Volumes mapping :
- [x]  /run/dbus:/run/dbus:ro
- [x]  ${APP_DATA_DIR}/data:/data
##### Specific instructions :
- [x]  🌐 Network mode (host)
- [x]  🔐 Security options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
    - Enabled dynamic configuration for Matter Server
    - Updated Tipi version to 17
    - Updated server configuration timestamp

- **Infrastructure**
    - Added Docker Compose configuration for Matter Server
    - Configured service with latest Python Matter Server image
    - Set up volume mappings and network settings for container deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->