### PR TITLE
Add dynamic compose for octobot

### DIFF
--- a/apps/octobot/config.json
+++ b/apps/octobot/config.json
@@ -3,8 +3,9 @@
   "port": 8825,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "octobot",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "2.0.7",
   "categories": ["automation", "finance"],
   "description": "OctoBot is a highly customizable trading bot using its configuration and tentacles system. You can build your own bot using the infinite configuration possibilities such as technical analysis, social media processing or even external statistics management like google trends.",
@@ -14,6 +15,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730034937000,
+  "updated_at": 1736983630321,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/octobot/docker-compose.json
+++ b/apps/octobot/docker-compose.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "octobot",
+      "image": "drakkarsoftware/octobot:2.0.7",
+      "isMain": true,
+      "internalPort": 5001,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/user",
+          "containerPath": "/octobot/user"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/tentacles",
+          "containerPath": "/octobot/tentacles"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/logs",
+          "containerPath": "/octobot/logs"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for octobot
This is a octobot update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://octobot.tipi.local
##### In app tests :
- [x]  📝 Register and log in
- [x]  💰 Create trading profiles
- [x]  📊 Check portfolio value
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/user:/octobot/user
- [x]  ${APP_DATA_DIR}/data/tentacles:/octobot/tentacles
- [x]  ${APP_DATA_DIR}/data/logs:/octobot/logs
##### Specific instructions :
- [x]  🌳 Environment
- 🏷 DNS (skipped)