### PR TITLE
Add dynamic compose for tooljet

### DIFF
--- a/apps/tooljet/config.json
+++ b/apps/tooljet/config.json
@@ -3,9 +3,10 @@
   "name": "Tooljet",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 9876,
   "id": "tooljet",
-  "tipi_version": 24,
+  "tipi_version": 25,
   "version": "2.4.2",
   "categories": ["automation"],
   "description": "ToolJet is an open-source low-code framework to build and deploy internal tools quickly with minimal engineering effort. ToolJet's drag and drop frontend builder allows you to build complicated responsive frontends within minutes. You can also connect to your data sources, such as databases ( PostgreSQL, MongoDB, Elasticsearch & more), API endpoints (ToolJet supports importing OpenAPI spec & OAuth2 authorization), SaaS tools (Stripe, Slack, Google Sheets, Airtable, Notion & more) and object storage services ( S3, GCS, Minio, etc ) to fetch and write data.",
@@ -38,5 +39,5 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1736983889196
 }

--- a/apps/tooljet/docker-compose.json
+++ b/apps/tooljet/docker-compose.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "tooljet",
+      "image": "tooljet/tooljet-client-ce:v2.4.2",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "SERVER_HOST": "tooljet-server"
+      },
+      "dependsOn": ["tooljet-server"],
+      "command": "openresty -g \"daemon off;\"",
+      "tty": true,
+      "stdinOpen": true
+    },
+    {
+      "name": "tooljet-server",
+      "image": "tooljet/tooljet-server-ce:v2.24.0",
+      "environment": {
+        "SERVE_CLIENT": "false",
+        "SERVER_HOST": "tooljet-server",
+        "TOOLJET_HOST": "https://${APP_DOMAIN}",
+        "LOCKBOX_MASTER_KEY": "${LOCKBOX_MASTER_KEY}",
+        "SECRET_KEY_BASE": "${SECRET_KEY_BASE}",
+        "PG_DB": "tooljet",
+        "PG_USER": "tooljet",
+        "PG_HOST": "db-tooljet",
+        "PG_PASS": "${DB_PASSWORD}",
+        "CHECK_FOR_UPDATES": "check_if_updates_are_available",
+        "DEFAULT_FROM_EMAIL": "hello@tooljet.io"
+      },
+      "command": "npm run start:prod",
+      "tty": true,
+      "stdinOpen": true
+    },
+    {
+      "name": "db-tooljet",
+      "image": "postgres:11",
+      "environment": {
+        "POSTGRES_USER": "tooljet",
+        "POSTGRES_PASSWORD": "${DB_PASSWORD}",
+        "POSTGRES_DB": "tooljet",
+        "PGDATA": "/data/postgres"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for tooljet
This is a tooljet update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://tooljet.tipi.local
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] ⌨ Command
- [x] 🔗 Depends on
- [x] 🔤 TTY (True)
- [x] 🤖 Stdin open
## Notes
- App outdated and broken, need rework