### PR TITLE
Add dynamic compose for homebridge

### DIFF
--- a/apps/homebridge/config.json
+++ b/apps/homebridge/config.json
@@ -3,7 +3,7 @@
   "name": "Home Bridge",
   "available": true,
   "port": 8581,
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "2024-05-02",
   "id": "homebridge",
   "categories": ["automation"],
@@ -14,5 +14,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983459729
 }

--- a/apps/homebridge/config.json
+++ b/apps/homebridge/config.json
@@ -2,6 +2,7 @@
   "$schema": "../app-info-schema.json",
   "name": "Home Bridge",
   "available": true,
+  "dynamic_config": true,
   "port": 8581,
   "tipi_version": 3,
   "version": "2024-05-02",

--- a/apps/homebridge/docker-compose.json
+++ b/apps/homebridge/docker-compose.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "homebridge",
+      "image": "homebridge/homebridge:2024-05-02",
+      "isMain": true,
+      "networkMode": "host",
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/homebridge",
+          "containerPath": "/homebridge"
+        }
+      ],
+      "privileged": true,
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "10mb",
+          "max-file": "1"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for homebridge
This is a homebridge update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:8581
- [ ] https://homebridge.tipi.lan (same as before)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🧩 Add plugin
- [x] 💡 Add integration
- [x] 🍎 Add to homekit
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/homebridge:/homebridge
##### Specific instructions :
- [x] 🌳 Environment (TZ)
- [x] 📄 Logging
- [x] 👑 Privileged