### PR TITLE
Add dynamic compose for suwayomi

### DIFF
--- a/apps/suwayomi/config.json
+++ b/apps/suwayomi/config.json
@@ -2,9 +2,10 @@
   "name": "Suwayomi",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 4567,
   "id": "suwayomi",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "1.1.1",
   "categories": ["books", "media"],
   "description": "A free and open-source manga reader server that runs extensions",
@@ -14,6 +15,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000,
+  "updated_at": 1736983864787,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/suwayomi/docker-compose.json
+++ b/apps/suwayomi/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "suwayomi",
+      "image": "ghcr.io/suwayomi/tachidesk:v1.1.1",
+      "isMain": true,
+      "internalPort": 4567,
+      "environment": {
+        "TZ": "${TZ}",
+        "BIND_IP": "0.0.0.0"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/home/suwayomi/.local/share/Tachidesk"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for suwayomi
This is a suwayomi update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://suwayomi.tipi.local
##### In app tests :
- [x] 🖱 Basic interaction
- [x] 📚 Connect to anime trackers
- [x] 🌆 Uploading books
- [x] 📖 Read manga
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data:/home/suwayomi/.local/share/Tachidesk
##### Specific instructions :
- [x]  🌳 Environment