### PR TITLE
Add dynamic compose for qdirstat

### DIFF
--- a/apps/qdirstat/config.json
+++ b/apps/qdirstat/config.json
@@ -4,8 +4,9 @@
   "port": 7125,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "qdirstat",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "1.8.1-ls82",
   "categories": ["utilities"],
   "description": "QDirStat Qt-based directory statistics: KDirStat without any KDE -- from the author of the original KDirStat.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983733028
 }

--- a/apps/qdirstat/docker-compose.json
+++ b/apps/qdirstat/docker-compose.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "qdirstat",
+      "image": "lscr.io/linuxserver/qdirstat:1.8.1-ls82",
+      "isMain": true,
+      "internalPort": 3000,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/qdirstat/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/qdirstat/app/data"
+        },
+        {
+          "hostPath": "/",
+          "containerPath": "/host",
+          "readOnly": true
+        }
+      ]
+    }
+  ]
+}

--- a/apps/qdirstat/docker-compose.json
+++ b/apps/qdirstat/docker-compose.json
@@ -9,7 +9,7 @@
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/qdirstat/config",
-          "containerPath": "/host"
+          "containerPath": "/config"
         },
         {
           "hostPath": "${APP_DATA_DIR}/data/qdirstat/app/data",

--- a/apps/qdirstat/docker-compose.json
+++ b/apps/qdirstat/docker-compose.json
@@ -8,10 +8,12 @@
       "internalPort": 3000,
       "volumes": [
         {
-          "hostPath": "${APP_DATA_DIR}/data/qdirstat/config"
+          "hostPath": "${APP_DATA_DIR}/data/qdirstat/config",
+          "containerPath": "/host"
         },
         {
-          "hostPath": "${APP_DATA_DIR}/data/qdirstat/app/data"
+          "hostPath": "${APP_DATA_DIR}/data/qdirstat/app/data",
+          "containerPath": "/data"
         },
         {
           "hostPath": "/",


### PR DESCRIPTION
## Dynamic compose for qdirstat
This is a qdirstat update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:7125
- [x] https://qdirstat.tipi.lan
##### In app tests :
- [x] 📊 Check storage usage
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/qdirstat/config
- [x] ${APP_DATA_DIR}/data/qdirstat/app/data
- [x] /:/host:ro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for qDirStat.
  - Introduced Docker Compose configuration for qDirStat service.

- **Configuration Updates**
  - Updated qDirStat configuration version from 1 to 2.
  - Modified configuration timestamp to reflect the latest update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->