### PR TITLE
Add dynamic compose for zerotier

### DIFF
--- a/apps/zerotier/config.json
+++ b/apps/zerotier/config.json
@@ -5,7 +5,7 @@
   "no_gui": true,
   "port": 9993,
   "id": "zerotier",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "1.14.2",
   "categories": ["network", "security"],
   "description": "ZeroTier combines the capabilities of VPN and SD-WAN, simplifying network management.",
@@ -26,5 +26,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1730917452000
+  "updated_at": 1736983970962
 }

--- a/apps/zerotier/config.json
+++ b/apps/zerotier/config.json
@@ -2,6 +2,7 @@
   "$schema": "../app-info-schema.json",
   "name": "ZeroTier",
   "available": true,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 9993,
   "id": "zerotier",

--- a/apps/zerotier/docker-compose.json
+++ b/apps/zerotier/docker-compose.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "zerotier",
+      "image": "zerotier/zerotier:1.14.2",
+      "isMain": true,
+      "networkMode": "host",
+      "command": "${NETWORK_ID}",
+      "devices": ["/dev/net/tun"],
+      "capAdd": ["NET_ADMIN", "SYS_ADMIN"],
+      "healthCheck": {
+        "test": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for zerotier
This is a zerotier update for using dynamic compose.
##### In app tests :
- [x] 📝 Register into Zerotier
- [x] 🆔 Add network id
- [x] ✅ Authorize node from Zerotier
##### Specific instructions :
- [x] 🩺 Healthcheck
- [x] ⌨ Command
- [x] 🌐 Network mode (host)
- [x] 📱 Devices
- [x] 🔓 Capacity add

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Updated ZeroTier configuration with dynamic config support
  - Incremented Tipi version to 9

- **New Features**
  - Added Docker Compose configuration for ZeroTier service
  - Configured ZeroTier to run with host network mode and specific capabilities

- **Service Improvements**
  - Updated to ZeroTier image version 1.14.2
  - Added basic health check for the service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->