### PR TITLE
Add dynamic compose for lodestone-core

### DIFF
--- a/apps/lodestone-core/config.json
+++ b/apps/lodestone-core/config.json
@@ -3,10 +3,11 @@
   "name": "Lodestone Core",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 16662,
   "id": "lodestone-core",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "0.5.1",
   "categories": ["gaming"],
   "description": "A free, open source server hosting tool for Minecraft and other multiplayers.",
@@ -17,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1736983530794
 }

--- a/apps/lodestone-core/docker-compose.json
+++ b/apps/lodestone-core/docker-compose.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "lodestone-core",
+      "image": "ghcr.io/lodestone-team/lodestone_core:0.5.1",
+      "isMain": true,
+      "internalPort": 16662,
+      "addPorts": [
+        {
+          "hostPort": "25565-25575",
+          "containerPort": "25565-25575"
+        }
+      ],
+      "user": "0:0",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/lodestone-data",
+          "containerPath": "/root/.lodestone"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for lodestone-core
This is a lodestone-core update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://lodestone-core.tipi.local
- [x] 🌐 Additionnal Ports (game server port)
##### In app tests :
- [x] 📝 Register and log in with setup key
- [x] 🕹 Set up Minecraft Server
- [x] 🎮 Connect from Minecraft
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/lodestone-data:/root/.lodestone
##### Specific instructions :
- [x] 👤 User (0:0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added dynamic configuration support
	- Updated Tipi version to 11
	- Updated configuration timestamp

- **Docker Configuration**
	- Added new Docker Compose configuration for Lodestone Core service
	- Configured service with version 0.5.1
	- Set up port mappings and volume persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->