### PR TITLE
Add dynamic compose for nitter

### DIFF
--- a/apps/nitter/config.json
+++ b/apps/nitter/config.json
@@ -3,9 +3,10 @@
   "name": "Nitter",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8106,
   "id": "nitter",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "latest",
   "categories": ["social"],
   "description": "A free and open source alternative Twitter front-end focused on privacy and performance.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1736983622993
 }

--- a/apps/nitter/docker-compose.json
+++ b/apps/nitter/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "nitter",
+      "image": "zedeus/nitter:latest",
+      "isMain": true,
+      "internalPort": 8080,
+      "dependsOn": ["nitter-redis"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nitter.conf",
+          "containerPath": "/src/nitter.conf",
+          "readOnly": true
+        }
+      ],
+      "healthCheck": {
+        "interval": "1m",
+        "timeout": "3s",
+        "test": "wget --no-verbose --tries=1 --spider http://localhost:8080"
+      }
+    },
+    {
+      "name": "nitter-redis",
+      "image": "redis:alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "redis-server --save 60 1 --loglevel warning"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for nitter
This is a nitter update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:8106
- [ ] https://nitter.tipi.lan (same as before)
##### In app tests :
- [x] 📝 Acces web interface
- 🐦 Try search 
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/nitter.conf:/src/nitter.conf:ro
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions verified :
- [x] 💻 Command
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated Nitter configuration with dynamic config setting
	- Incremented Tipi version to 4
	- Updated configuration timestamp

- **Infrastructure**
	- Added Docker Compose configuration for Nitter
	- Introduced Nitter and Redis services with latest images
	- Configured service health checks and persistent data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->