### PR TITLE
Add dynamic compos for n8n-1

### DIFF
--- a/apps/n8n-1/config.json
+++ b/apps/n8n-1/config.json
@@ -3,9 +3,10 @@
   "name": "n8n",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8215,
   "id": "n8n-1",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "1.73.1",
   "categories": ["automation"],
   "description": "n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, be available to self-host, and allow you to add your own custom functions, logic and apps. n8n's node-based approach makes it highly versatile, enabling you to connect anything to everything.",
@@ -29,5 +30,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1731435598000
+  "updated_at": 1738177531166
 }

--- a/apps/n8n-1/docker-compose.json
+++ b/apps/n8n-1/docker-compose.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "n8n-1",
+      "image": "n8nio/n8n:1.73.1",
+      "isMain": true,
+      "internalPort": 5678,
+      "environment": {
+        "N8N_EDITOR_BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "N8N_SECURE_COOKIE": "false",
+        "WEBHOOK_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "DB_TYPE": "postgresdb",
+        "DB_POSTGRESDB_HOST": "n8n-db",
+        "DB_POSTGRESDB_PORT": "5432",
+        "DB_POSTGRESDB_DATABASE": "n8n",
+        "DB_POSTGRESDB_USER": "n8n",
+        "DB_POSTGRESDB_PASSWORD": "${N8N_NR_DB_PASSWORD}"
+      },
+      "dependsOn": {
+        "n8n-init": {
+          "condition": "service_completed_successfully"
+        },
+        "n8n-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/n8n",
+          "containerPath": "/home/node/.n8n"
+        }
+      ]
+    },
+    {
+      "name": "n8n-db",
+      "image": "postgres:11",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${N8N_DB_PASSWORD}",
+        "POSTGRES_DB": "n8n",
+        "POSTGRES_NON_ROOT_USER": "n8n",
+        "POSTGRES_NON_ROOT_PASSWORD": "${N8N_NR_DB_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/init-data.sh",
+          "containerPath": "/docker-entrypoint-initdb.d/init-data.sh"
+        }
+      ],
+      "healthCheck": {
+        "interval": "5s",
+        "timeout": "5s",
+        "retries": 10,
+        "test": "pg_isready -h localhost -U $$POSTGRES_USER -d $$POSTGRES_DB"
+      }
+    },
+    {
+      "name": "n8n-init",
+      "image": "bash:5.2.37",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/n8n",
+          "containerPath": "/home/node/.n8n"
+        }
+      ],
+      "command": ["sh", "-c", "chown -R 1000:1000 /home/node/.n8n"]
+    }
+  ]
+}

--- a/apps/n8n-1/docker-compose.json
+++ b/apps/n8n-1/docker-compose.json
@@ -18,9 +18,6 @@
         "DB_POSTGRESDB_PASSWORD": "${N8N_NR_DB_PASSWORD}"
       },
       "dependsOn": {
-        "n8n-init": {
-          "condition": "service_completed_successfully"
-        },
         "n8n-db": {
           "condition": "service_healthy"
         }
@@ -58,17 +55,6 @@
         "retries": 10,
         "test": "pg_isready -h localhost -U $$POSTGRES_USER -d $$POSTGRES_DB"
       }
-    },
-    {
-      "name": "n8n-init",
-      "image": "bash:5.2.37",
-      "volumes": [
-        {
-          "hostPath": "${APP_DATA_DIR}/data/n8n",
-          "containerPath": "/home/node/.n8n"
-        }
-      ],
-      "command": ["sh", "-c", "chown -R 1000:1000 /home/node/.n8n"]
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for n8n-1
This is a n8n-1 update for using dynamic compose.
##### Situation tested :
- 💾 Update on existing data
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8215
- [x] https://n8n-1.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x] ⚙ Create a workflow
- [x] 🌐 Call workflow with webhook
   - [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/n8n:/home/node/.n8n
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/init-data.sh:/docker-entrypoint-initdb.d/init-data.sh
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command
- [x] 🩺 Healthcheck
- [x]   Depends on (n8n-init removed)

## Additionnal note
Service n8n-init (introduced in #3557) has been removed, it was preventing the app to start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic configuration support for the application
	- Introduced Docker Compose configuration for n8n application and PostgreSQL database
	- Updated application to version 9

- **Configuration Changes**
	- Updated application version and timestamp
	- Configured environment variables and service dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->