### PR TITLE
Add dynamic compose for gladys

### DIFF
--- a/apps/gladys/config.json
+++ b/apps/gladys/config.json
@@ -4,8 +4,9 @@
   "port": 8270,
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "id": "gladys",
-  "tipi_version": 49,
+  "tipi_version": 50,
   "version": "4.51.0",
   "categories": ["automation"],
   "description": "A privacy-first, open-source home assistant",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1737381900000
+  "updated_at": 1738177445599
 }

--- a/apps/gladys/docker-compose.json
+++ b/apps/gladys/docker-compose.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "gladys",
+      "image": "gladysassistant/gladys:v4.51.0",
+      "isMain": true,
+      "networkMode": "host",
+      "environment": {
+        "NODE_ENV": "production",
+        "SERVER_PORT": "8270",
+        "TZ": "${TZ}",
+        "SQLITE_FILE_PATH": "/var/lib/gladysassistant/gladys-production.db"
+      },
+      "volumes": [
+        {
+          "hostPath": "/var/run/docker.sock",
+          "containerPath": "/var/run/docker.sock"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/gladysassistant",
+          "containerPath": "/var/lib/gladysassistant"
+        },
+        {
+          "hostPath": "/dev",
+          "containerPath": "/dev"
+        },
+        {
+          "hostPath": "/run/udev",
+          "containerPath": "/run/udev",
+          "readOnly": true
+        }
+      ],
+      "privileged": true,
+      "stopGracePeriod": "1m"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for gladys
This is a gladys update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [ ] https://gladys.tipi.lan (same as before)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🧩 Add intergration
- [x] 🌆 Uploading data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] /var/run/docker.sock:/var/run/docker.sock
- [x] ${APP_DATA_DIR}/data/gladysassistant:/var/lib/gladysassistant
- [x] /dev:/dev
- [x] /run/udev:/run/udev:ro
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🌐 Network mode (host)
- [x] 👑 Privileged
- [x] 👼 Stop grace period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic configuration in Gladys Assistant
  - Updated Docker Compose configuration for Gladys service

- **Chores**
  - Incremented Tipi version to 50
  - Updated configuration timestamp
  - Deployed Gladys Assistant version 4.51.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->