### PR TITLE
Add dynamic compose for semaphore

### DIFF
--- a/apps/semaphore/config.json
+++ b/apps/semaphore/config.json
@@ -8,11 +8,12 @@
   "port": 8526,
   "categories": ["development"],
   "description": "Semaphore is a modern UI for Ansible, Terraform/OpenTofu, Bash and Pulumi. It lets you easily run Ansible playbooks, get notifications about fails, control access to deployment system.",
-  "tipi_version": 21,
+  "tipi_version": 22,
   "version": "2.11.2",
   "source": "https://github.com/semaphoreui/semaphore",
   "website": "https://semaphoreui.com",
   "exposable": true,
+  "dynamic_config": true,
   "supported_architectures": ["arm64", "amd64"],
   "form_fields": [
     {
@@ -48,5 +49,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1735223263000
+  "updated_at": 1738177598822
 }

--- a/apps/semaphore/docker-compose.json
+++ b/apps/semaphore/docker-compose.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "semaphore",
+      "image": "semaphoreui/semaphore:v2.11.2",
+      "isMain": true,
+      "internalPort": 3000,
+      "environment": {
+        "SEMAPHORE_DB_USER": "semaphore",
+        "SEMAPHORE_DB_PASS": "${SEMAPHORE_DB_PASSWORD}",
+        "SEMAPHORE_DB_HOST": "semaphore-db",
+        "SEMAPHORE_DB_PORT": "5432",
+        "SEMAPHORE_DB_DIALECT": "postgres",
+        "SEMAPHORE_DB": "semaphore",
+        "SEMAPHORE_PLAYBOOK_PATH": "/tmp/semaphore",
+        "SEMAPHORE_ADMIN_PASSWORD": "${SEMAPHORE_ADMIN_PASSWORD}",
+        "SEMAPHORE_ADMIN_NAME": "${SEMAPHORE_ADMIN_NAME}",
+        "SEMAPHORE_ADMIN_EMAIL": "${SEMAPHORE_ADMIN_EMAIL}",
+        "SEMAPHORE_ADMIN": "${SEMAPHORE_ADMIN_NAME}",
+        "SEMAPHORE_ACCESS_KEY_ENCRYPTION": "${SEMAPHORE_ACCESS_KEY_ENCRYPTION}",
+        "SEMAPHORE_LDAP_ACTIVATED": "no",
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/repositories",
+          "containerPath": "/repositories"
+        }
+      ]
+    },
+    {
+      "name": "semaphore-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_USER": "semaphore",
+        "POSTGRES_PASSWORD": "${SEMAPHORE_DB_PASSWORD}",
+        "POSTGRES_DB": "semaphore"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for semaphore
This is a semaphore update for using dynamic compose. (no other change)
##### Situation tested :
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:8526
- [x] https://semaphore.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x] 📈 Execute a task
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/repositories:/repositories
- [x] ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
##### Specific instructions verified :
- [x] 🌳 Environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic configuration support for Semaphore
  - Introduced Docker Compose configuration for Semaphore application
  - Deployed Semaphore UI version 2.11.2 with PostgreSQL database integration

- **Chores**
  - Updated Tipi version from 21 to 22
  - Updated configuration timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->