### PR TITLE
Add dynamic compose for tailscale

### DIFF
--- a/apps/tailscale/config.json
+++ b/apps/tailscale/config.json
@@ -3,10 +3,11 @@
   "name": "Tailscale",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 8093,
   "id": "tailscale",
-  "tipi_version": 38,
+  "tipi_version": 39,
   "version": "1.78.3",
   "categories": ["network", "security"],
   "description": "Zero config VPN. Installs on any device in minutes, manages firewall rules for you, and works from anywhere.",
@@ -63,5 +64,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734026149000
+  "updated_at": 1738177633406
 }

--- a/apps/tailscale/docker-compose.json
+++ b/apps/tailscale/docker-compose.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "tailscale",
+      "image": "tailscale/tailscale:v1.78.3",
+      "isMain": true,
+      "environment": {
+        "TS_SERVE_CONFIG": "${TAILSCALE_SERVE_CONFIG}",
+        "TS_ACCEPT_DNS": "${TAILSCALE_ACCEPT_DNS-false}",
+        "TS_AUTH_ONCE": "${TAILSCALE_AUTH_ONCE-false}",
+        "TS_AUTHKEY": "${TAILSCALE_AUTHKEY}",
+        "TS_HOSTNAME": "${TAILSCALE_HOSTNAME-runtipi}",
+        "TS_ROUTES": "${TAILSCALE_ROUTES}",
+        "TS_EXTRA_ARGS": "${TAILSCALE_EXTRA_ARGS}",
+        "TS_USERSPACE": "${TAILSCALE_USERSPACE-true}",
+        "TS_STATE_DIR": "/var/lib/tailscale"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/state",
+          "containerPath": "/var/lib/tailscale"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "/dev/net/tun",
+          "containerPath": "/dev/net/tun"
+        }
+      ],
+      "capAdd": ["net_admin", "sys_module"]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for tailscale
This is a tailscale update for using dynamic compose.
##### Reaching the app :
- [x] To be determined by @nicotsx 
##### In app tests :
- [x] To be determined by @nicotsx 
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/state:/var/lib/tailscale
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] /dev/net/tun:/dev/net/tun
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔓 Capacity add

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Dynamic Configuration**: Enabled dynamic configuration support with updated version tracking.
  - **Enhanced Deployment**: Introduced a containerized deployment configuration with preset environment variables, persistent storage options, and improved network capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->