### PR TITLE
[Glance] fix breaking change (v0.7) - new config directory

### DIFF
--- a/apps/glance/config.json
+++ b/apps/glance/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "glance",
-  "tipi_version": 11,
+  "tipi_version": 12,
   "version": "0.7.1",
   "categories": ["utilities"],
   "description": "A self-hosted dashboard that puts all your feeds in one place",
@@ -16,5 +16,5 @@
   "supported_architectures": ["arm64", "amd64"],
   "dynamic_config": true,
   "created_at": 1691943801422,
-  "updated_at": 1739193979000
+  "updated_at": 1739267021010
 }

--- a/apps/glance/docker-compose.json
+++ b/apps/glance/docker-compose.json
@@ -7,7 +7,7 @@
       "isMain": true,
       "volumes": [
         {
-          "hostPath": "${APP_DATA_DIR}/data/config",
+          "hostPath": "${APP_DATA_DIR}/data/",
           "containerPath": "/app/config/"
         }
       ]

--- a/apps/glance/docker-compose.json
+++ b/apps/glance/docker-compose.json
@@ -8,7 +8,7 @@
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/glance.yml",
-          "containerPath": "/app/glance.yml"
+          "containerPath": "/app/config/glance.yml"
         }
       ]
     }

--- a/apps/glance/docker-compose.json
+++ b/apps/glance/docker-compose.json
@@ -7,8 +7,8 @@
       "isMain": true,
       "volumes": [
         {
-          "hostPath": "${APP_DATA_DIR}/data/glance.yml",
-          "containerPath": "/app/config/glance.yml"
+          "hostPath": "${APP_DATA_DIR}/data/",
+          "containerPath": "/app/config/"
         }
       ]
     }

--- a/apps/glance/docker-compose.json
+++ b/apps/glance/docker-compose.json
@@ -7,7 +7,7 @@
       "isMain": true,
       "volumes": [
         {
-          "hostPath": "${APP_DATA_DIR}/data/",
+          "hostPath": "${APP_DATA_DIR}/data/config",
           "containerPath": "/app/config/"
         }
       ]

--- a/apps/glance/docker-compose.yml
+++ b/apps/glance/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - ${APP_PORT}:8080
     volumes:
-      - ${APP_DATA_DIR}/data/glance.yml:/app/glance.yml
+      - ${APP_DATA_DIR}/data/:/app/config/
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     networks:


### PR DESCRIPTION
Details here :
https://github.com/glanceapp/glance/blob/main/docs/v0.7.0-upgrade.md


### Before

Versions before v0.7.0 used a `docker-compose.yml` that looked like the following:

```yaml
services:
  glance:
    volumes:
      - ./glance.yml:/app/glance.yml
    ports:
      - 8080:8080
```
### After

With the release of v0.7.0, the recommended `docker-compose.yml` looks like the following:

```yaml
services:
  glance:
    volumes:
      - ./config:/app/config
```