### PR TITLE
Add dynamic compose for kimai

### DIFF
--- a/apps/kimai/config.json
+++ b/apps/kimai/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8003,
   "exposable": true,
+  "dynamic_config": true,
   "id": "kimai",
   "description": "Kimai is a professional grade time-tracking application, free and open-source. It handles use-cases of freelancers as well as companies with dozens or hundreds of users.",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "fpm-2.1.0-prod",
   "categories": ["utilities"],
   "short_desc": "Open source time-tracker",
@@ -44,6 +45,6 @@
   ],
   "supported_architectures": ["amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1724410930192,
+  "updated_at": 1738177468828,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/kimai/config.json
+++ b/apps/kimai/config.json
@@ -7,7 +7,7 @@
   "id": "kimai",
   "description": "Kimai is a professional grade time-tracking application, free and open-source. It handles use-cases of freelancers as well as companies with dozens or hundreds of users.",
   "tipi_version": 3,
-  "version": "fpm-2.1.0-prod",
+  "version": "fpm-2.19.1-prod",
   "categories": ["utilities"],
   "short_desc": "Open source time-tracker",
   "author": "Kevin Papst",

--- a/apps/kimai/docker-compose.json
+++ b/apps/kimai/docker-compose.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "nginx",
+      "image": "tobybatch/nginx-fpm-reverse-proxy:latest",
+      "internalPort": 80,
+      "dependsOn": ["kimai"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/public",
+          "containerPath": "/opt/kimai/public",
+          "readOnly": true
+        }
+      ],
+      "healthCheck": {
+        "interval": "20s",
+        "timeout": "10s",
+        "retries": 3,
+        "startPeriod": "10s",
+        "test": "wget --spider http://kimai-proxy/health || exit 1"
+      }
+    },
+    {
+      "name": "kimai",
+      "image": "kimai/kimai2:fpm-2.1.0-prod",
+      "isMain": true,
+      "environment": {
+        "ADMINMAIL": "${KIMAI_ADMINMAIL}",
+        "ADMINPASS": "${KIMAI_ADMINPASS}",
+        "DATABASE_URL": "mysql://kimai:${KIMAI_DATABASE_PASSWORD}@kimai-sqldb/kimai?charset",
+        "TRUSTED_HOSTS": "kimai-proxy,localhost,127.0.0.1"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/public",
+          "containerPath": "/opt/kimai/public"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/var",
+          "containerPath": "/opt/kimai/var"
+        }
+      ]
+    },
+    {
+      "name": "sqldb",
+      "image": "mysql:5.7",
+      "environment": {
+        "MYSQL_DATABASE": "kimai",
+        "MYSQL_USER": "kimai",
+        "MYSQL_PASSWORD": "${KIMAI_DATABASE_PASSWORD}",
+        "MYSQL_ROOT_PASSWORD": "${KIMAI_DATABASE_ROOT_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "command": "--default-storage-engine innodb",
+      "healthCheck": {
+        "interval": "20s",
+        "timeout": "10s",
+        "retries": 3,
+        "startPeriod": "10s",
+        "test": "mysqladmin -p$$MYSQL_ROOT_PASSWORD ping -h localhost"
+      }
+    }
+  ]
+}

--- a/apps/kimai/docker-compose.json
+++ b/apps/kimai/docker-compose.json
@@ -2,8 +2,9 @@
   "$schema": "../dynamic-compose-schema.json",
   "services": [
     {
-      "name": "nginx",
+      "name": "kimai-proxy",
       "image": "tobybatch/nginx-fpm-reverse-proxy:latest",
+      "isMain": true,
       "internalPort": 80,
       "dependsOn": ["kimai"],
       "volumes": [
@@ -23,12 +24,11 @@
     },
     {
       "name": "kimai",
-      "image": "kimai/kimai2:fpm-2.1.0-prod",
-      "isMain": true,
+      "image": "kimai/kimai2:fpm-2.19.1-prod",
       "environment": {
         "ADMINMAIL": "${KIMAI_ADMINMAIL}",
         "ADMINPASS": "${KIMAI_ADMINPASS}",
-        "DATABASE_URL": "mysql://kimai:${KIMAI_DATABASE_PASSWORD}@kimai-sqldb/kimai?charset",
+        "DATABASE_URL": "mysql://kimai:${KIMAI_DATABASE_PASSWORD}@kimai-sqldb/kimai?charset=utf8&serverVersion=5.7",
         "TRUSTED_HOSTS": "kimai-proxy,localhost,127.0.0.1"
       },
       "volumes": [
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "name": "sqldb",
+      "name": "kimai-sqldb",
       "image": "mysql:5.7",
       "environment": {
         "MYSQL_DATABASE": "kimai",

--- a/apps/kimai/docker-compose.yml
+++ b/apps/kimai/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       runtipi.managed: true
   kimai:
     container_name: kimai
-    image: kimai/kimai2:fpm-2.1.0-prod
+    image: kimai/kimai2:fpm-2.19.1-prod
     environment:
       - ADMINMAIL=${KIMAI_ADMINMAIL}
       - ADMINPASS=${KIMAI_ADMINPASS}


### PR DESCRIPTION
## Dynamic compose for kimai
This is a kimai update for using dynamic compose.
##### Situation tested :
- 👶 Fresh install of the app
- 💾 Update on existing data
##### Reaching the app :
- [x] http://localip:8003
- [ ] https://kimai.tipi.lan (unchanged)
##### In app tests :
- [x] 📝 Register and log in
- [x] 👔 Create project, client and activity
- [x] ⏱ Track an activity
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/public:/opt/kimai/public:ro
- [x] ${APP_DATA_DIR}/data/public:/opt/kimai/public
- [x] ${APP_DATA_DIR}/data/var:/opt/kimai/var
- [x] ${APP_DATA_DIR}/data/mysql:/var/lib/mysql
##### Specific instructions verified :
- [x] 🌳 Environment
- [x] 💻 Command
- [x] 🩺 Healthcheck
- [x] 🔗 Depends on
## Other change
Update to **2.19.1**