### PR TITLE
fix: Make lubelogger readOnly property camelCase

### DIFF
--- a/apps/lubelogger/config.json
+++ b/apps/lubelogger/config.json
@@ -5,7 +5,7 @@
   "available": true,
   "exposable": true,
   "id": "lubelogger",
-  "tipi_version": 15,
+  "tipi_version": 16,
   "version": "1.4.4",
   "dynamic_config": true,
   "categories": ["utilities"],

--- a/apps/lubelogger/docker-compose.json
+++ b/apps/lubelogger/docker-compose.json
@@ -9,7 +9,7 @@
         {
           "hostPath": "/etc/localtime",
           "containerPath": "/etc/localtime",
-          "readonly": true
+          "readOnly": true
         },
         {
           "hostPath": "${APP_DATA_DIR}/data/config",
@@ -76,7 +76,7 @@
         {
           "hostPath": "${APP_DATA_DIR}/data/init/init-db.sh",
           "containerPath": "/docker-entrypoint-initdb.d/init-db.sh",
-          "readonly": true
+          "readOnly": true
         },
         {
           "hostPath": "${APP_DATA_DIR}/data/postgres",


### PR DESCRIPTION
This is just a consistency improvement, as other apps are also using it with this spelling. I'm not sure if the "old" spelling even took effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized configuration naming for volume permissions to align with naming conventions without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->