### PR TITLE
Fix Crowdsec swapped services images

### DIFF
--- a/apps/crowdsec/config.json
+++ b/apps/crowdsec/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "crowdsec",
-  "tipi_version": 7,
+  "tipi_version": 8,
   "version": "1.6.5",
   "categories": ["security", "utilities"],
   "description": "CrowdSec is a free, modern & collaborative behavior detection engine, coupled with a global IP reputation network. It stacks on fail2ban's philosophy but is IPV6 compatible and 60x faster (Go vs Python), it uses Grok patterns to parse logs and YAML scenarios to identify behaviors. CrowdSec is engineered for modern Cloud / Containers / VM-based infrastructures (by decoupling detection and remediation). Once detected you can remedy threats with various bouncers (firewall block, nginx http 403, Captchas, etc.) while the aggressive IP can be sent to CrowdSec for curation before being shared among all users to further improve everyone's security. See FAQ or read below for more.",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1739207719000
+  "updated_at": 1740041598712
 }

--- a/apps/crowdsec/docker-compose.json
+++ b/apps/crowdsec/docker-compose.json
@@ -2,7 +2,7 @@
   "$schema": "../dynamic-compose-schema.json",
   "services": [
     {
-      "image": "crowdsecurity/crowdsec:v1.6.4",
+      "image": "crowdsecurity/crowdsec:v1.6.5",
       "name": "crowdsec",
       "volumes": [
         {
@@ -58,7 +58,7 @@
       "dependsOn": ["crowdsec"]
     },
     {
-      "image": "crowdsecurity/crowdsec:v1.6.5",
+      "image": "metabase/metabase",
       "name": "crowdsec-dashboard",
       "internalPort": 3000,
       "isMain": true,


### PR DESCRIPTION
Last update, Renovate had replaced metabase with crowdsec images and didn't update the real crowdsec service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application's configuration to align with the latest release, ensuring improved performance.
  - Enhanced backend service components now deliver a refreshed dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->