### PR TITLE
Add dynamic compose for electrs

### DIFF
--- a/apps/electrs/config.json
+++ b/apps/electrs/config.json
@@ -3,11 +3,12 @@
   "name": "Electrs",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": false,
   "port": 3006,
   "id": "electrs",
   "description": "Electrum server",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "v0.10.6",
   "categories": ["finance"],
   "short_desc": "Electrum server",
@@ -31,5 +32,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1731513445000
+  "updated_at": 1740331616142
 }

--- a/apps/electrs/docker-compose.json
+++ b/apps/electrs/docker-compose.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "electrs-ui",
+      "image": "ghcr.io/montejojorge/electrs-ui:v0.9.2",
+      "internalPort": 3006,
+      "environment": {
+        "BITCOIND_DIR": "/data/.bitcoin",
+        "ELECTRUM_LOCAL_DOMAIN": "runtipi.home",
+        "ELECTRUM_IP_ADDRESS": "${INTERNAL_IP}",
+        "ELECTRS_HOST": "electrs",
+        "BITCOIND_HOST": "${BITCOIND_HOST:-bitcoind}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${BITCOIND_DIR",
+          "containerPath": "-${APP_DATA_DIR}/../bitcoind/data}"
+        }
+      ]
+    },
+    {
+      "name": "electrs",
+      "image": "getumbrel/electrs:v0.10.6",
+      "isMain": true,
+      "addPorts": [
+        {
+          "hostPort": 50001,
+          "containerPort": 50001
+        }
+      ],
+      "user": "0:0",
+      "environment": {
+        "ELECTRS_COOKIE_FILE": "/data/.bitcoin/.cookie",
+        "ELECTRS_DB_DIR": "/data/db",
+        "ELECTRS_ELECTRUM_RPC_ADDR": "0.0.0.0:50001",
+        "ELECTRS_LOG_FILTERS": "INFO",
+        "ELECTRS_DAEMON_RPC_ADDR": "${BITCOIND_HOST:-bitcoind}:8332",
+        "ELECTRS_DAEMON_P2P_ADDR": "${BITCOIND_HOST:-bitcoind}:8333"
+      },
+      "volumes": [
+        {
+          "hostPath": "${BITCOIND_DIR",
+          "containerPath": "-${APP_DATA_DIR}/../bitcoind/data}"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        }
+      ],
+      "stopGracePeriod": "15m"
+    }
+  ]
+}

--- a/apps/electrs/docker-compose.json
+++ b/apps/electrs/docker-compose.json
@@ -4,6 +4,7 @@
     {
       "name": "electrs-ui",
       "image": "ghcr.io/montejojorge/electrs-ui:v0.9.2",
+      "isMain": true,
       "internalPort": 3006,
       "environment": {
         "BITCOIND_DIR": "/data/.bitcoin",
@@ -14,8 +15,9 @@
       },
       "volumes": [
         {
-          "hostPath": "${BITCOIND_DIR",
-          "containerPath": "-${APP_DATA_DIR}/../bitcoind/data}"
+          "hostPath": "${BITCOIND_DIR:-${APP_DATA_DIR}/../bitcoind/data}",
+          "containerPath": "/data/.bitcoin",
+          "readOnly": true
         }
       ]
     },
@@ -40,8 +42,9 @@
       },
       "volumes": [
         {
-          "hostPath": "${BITCOIND_DIR",
-          "containerPath": "-${APP_DATA_DIR}/../bitcoind/data}"
+          "hostPath": "${BITCOIND_DIR:-${APP_DATA_DIR}/../bitcoind/data}",
+          "containerPath": "/data/.bitcoin",
+          "readOnly": true
         },
         {
           "hostPath": "${APP_DATA_DIR}/data",


### PR DESCRIPTION
## Dynamic compose for electrs
This is a electrs update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [ ] https://electrs.tipi.local
- [x] 🌐 Additionnal Port (3001)

##### In app tests :
- [x]  📝 Connect to bitcoind
- [x]  🖱 Basic interaction
##### Volumes mapping :
- [x]  ${BITCOIND_DIR:-${APP_DATA_DIR}/../bitcoind/data}:/data/.bitcoin:ro
- [x]  ${BITCOIND_DIR:-${APP_DATA_DIR}/../bitcoind/data}:/data/.bitcoin:ro
- [x]  ${APP_DATA_DIR}/data:/data
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (0:0)
- [x]  👼 Stop grace period