### PR TITLE
Add dynamic compose for kasm-workspaces

### DIFF
--- a/apps/kasm-workspaces/config.json
+++ b/apps/kasm-workspaces/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8744,
   "exposable": false,
+  "dynamic_config": true,
   "id": "kasm-workspaces",
   "description": "Kasm Workspaces is a docker container streaming platform for delivering browser-based access to desktops, applications, and web services.",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "1.120.20221218",
   "categories": ["utilities"],
   "short_desc": "Container streaming platform.",
@@ -16,6 +17,6 @@
   "supported_architectures": ["arm64", "amd64"],
   "https": true,
   "created_at": 1691943801422,
-  "updated_at": 1723566284000,
+  "updated_at": 1740331649814,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/kasm-workspaces/docker-compose.json
+++ b/apps/kasm-workspaces/docker-compose.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "kasm-workspaces",
+      "image": "lscr.io/linuxserver/kasm:1.120.20221218",
+      "isMain": true,
+      "internalPort": "${APP_PORT}",
+      "addPorts": [
+        {
+          "hostPort": 8743,
+          "containerPort": 3000
+        }
+      ],
+      "environment": {
+        "KASM_PORT": "${APP_PORT}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/opt"
+        }
+      ],
+      "privileged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for kasm-workspaces
This is a kasm-workspaces update for using dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://kasm-workspaces.tipi.local (refused by app)
- [x] 🌐 Additionnal Port(s)
##### In app tests :
- [x] 🧙‍♂️ Inital wizard installation
- [x] 📝Register and log in
- [x] 🖱 Interact with app
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data:/opt
##### Specific instructions :
- [x] 🌳 Environment
- [x] 👑 Privileged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic configuration for the application, offering enhanced flexibility.
  - Updated version and timestamp details to reflect the latest configuration.
  - Introduced a containerized deployment option with refined port mapping and storage settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->