### PR TITLE
Add dynamic compose for moneroblock

### DIFF
--- a/apps/moneroblock/config.json
+++ b/apps/moneroblock/config.json
@@ -3,9 +3,10 @@
   "name": "Moneroblock",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 31312,
   "id": "moneroblock",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "0.1.2",
   "categories": ["utilities"],
   "description": "MoneroBlock is a trustless block explorer for the Monero payment network.",
@@ -25,5 +26,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566284000
+  "updated_at": 1740331697595
 }

--- a/apps/moneroblock/docker-compose.json
+++ b/apps/moneroblock/docker-compose.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "moneroblock",
+      "image": "sethsimmons/moneroblock:v0.1.2",
+      "isMain": true,
+      "internalPort": 31312,
+      "command": ["--daemon", "${DAEMON_ADDRESS:-node.sethforprivacy.com:18089}"]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for moneroblock
This is a moneroblock update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://moneroblock.tipi.local
##### In app tests :
- [x] 🖱 Basic interaction
##### Specific instructions :
- [x] ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration with an updated version for improved system flexibility.
	- Introduced a new container deployment setup for the service with streamlined orchestration and preset connection defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->