### PR TITLE
Add dynamic compose for monerod

### DIFF
--- a/apps/monerod/config.json
+++ b/apps/monerod/config.json
@@ -3,10 +3,11 @@
   "name": "Monero Daemon",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 18080,
   "id": "monerod",
-  "tipi_version": 12,
+  "tipi_version": 13,
   "version": "0.18.3.4",
   "categories": ["finance"],
   "description": "A device on the Internet running the Monero software, with a full copy of the Monero blockchain, actively assisting the Monero network. This is a simple and straightforward Dockerized monerod built from source and exposing standard ports. Please note that running this requires >50GB of free disk space and is best run on solid-state (SSD) storage.",
@@ -18,6 +19,6 @@
   "gid": 1000,
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740247420440,
+  "updated_at": 1740331704535,
   "force_pull": true
 }

--- a/apps/monerod/docker-compose.json
+++ b/apps/monerod/docker-compose.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "monerod",
+      "image": "sethsimmons/simple-monerod:v0.18.3.4",
+      "isMain": true,
+      "internalPort": 18080,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/home/monero/.bitmonero"
+        }
+      ],
+      "command": "--rpc-restricted-bind-ip=0.0.0.0 --rpc-restricted-bind-port=18089 --public-node --no-igd --enable-dns-blocklist --prune-blockchain --zmq-pub=tcp://0.0.0.0:18083"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for monerod
This is a monerod update for dynamic compose.
##### In app tests :
- [x]  💱 Check synchronization
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data:/home/monero/.bitmonero
##### Specific instructions :
- [x]  ⌨ Command
- 🏷 DNS (skipped)