### PR TITLE
Add dynamic compose for qbittorrent

### DIFF
--- a/apps/qbittorrent/config.json
+++ b/apps/qbittorrent/config.json
@@ -3,9 +3,10 @@
   "name": "qBittorrent",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8133,
   "id": "qbittorrent",
-  "tipi_version": 23,
+  "tipi_version": 24,
   "version": "5.0.4",
   "categories": ["utilities"],
   "description": "qBittorrent is a fast, easy, and free BitTorrent client.",
@@ -15,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740005487000
+  "updated_at": 1740331761153
 }

--- a/apps/qbittorrent/docker-compose.json
+++ b/apps/qbittorrent/docker-compose.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "qbittorrent",
+      "image": "lscr.io/linuxserver/qbittorrent:5.0.4",
+      "isMain": true,
+      "internalPort": "${APP_PORT}",
+      "addPorts": [
+        {
+          "hostPort": 6881,
+          "containerPort": 6881,
+          "udp": true
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "WEBUI_PORT": "${APP_PORT}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents",
+          "containerPath": "/media/torrents"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for qbittorrent
This is a qbittorrent update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://qbittorrent.tipi.local
- [x]  Additionnal Port (6881)
##### In app tests :
- [x] 📝 Login
- [x] 🌊 Add torrent
- [x] 🔎 Complete a download and check received data
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/config:/config
- [x]  ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
##### Specific instructions :
- [x]  🌳 Environment
- 🏷 DNS (skipped)