### PR TITLE
Dynamic compose/rsshub

### DIFF
--- a/apps/rsshub/config.json
+++ b/apps/rsshub/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8223,
   "exposable": true,
+  "dynamic_config": true,
   "id": "rsshub",
   "description": "RSSHub is an open source, easy to use, and extensible RSS feed generator. It's capable of generating RSS feeds from pretty much everything.",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "2024-04-17",
   "categories": ["utilities", "media"],
   "short_desc": "Everything is RSSible with RSSHub",
@@ -25,7 +26,7 @@
   ],
   "supported_architectures": ["amd64", "arm64"],
   "created_at": 1691943801422,
-  "updated_at": 1740247420440,
+  "updated_at": 1740331775282,
   "$schema": "../app-info-schema.json",
   "force_pull": true
 }

--- a/apps/rsshub/docker-compose.json
+++ b/apps/rsshub/docker-compose.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "rsshub",
+      "image": "diygod/rsshub:2024-04-17",
+      "isMain": true,
+      "internalPort": 1200,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "dependsOn": ["redis", "browserless"]
+    },
+    {
+      "name": "browserless",
+      "image": "browserless/chrome",
+      "ulimits": {
+        "core": {
+          "soft": 0,
+          "hard": 0
+        }
+      }
+    },
+    {
+      "name": "redis",
+      "image": "redis:alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/rsshub/docker-compose.json
+++ b/apps/rsshub/docker-compose.json
@@ -7,7 +7,10 @@
       "isMain": true,
       "internalPort": 1200,
       "environment": {
-        "TZ": "${TZ}"
+        "TZ": "${TZ}",
+        "NODE_ENV": "production",
+        "PUPPETEER_WS_ENDPOINT": "ws://rsshub-browserless:3000",
+        "REDIS_URL": "redis://rsshub-redis:6379/"
       },
       "dependsOn": ["redis", "browserless"]
     },


### PR DESCRIPTION
## Dynamic compose for rsshub
This is a rsshub update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://rsshub.tipi.local
##### In app tests :
- [x]  📝 Access welcome page
- [x]  🛣 Test route
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🧱 Ulimits