### PR TITLE
Add dynamic compose for sftpgo

### DIFF
--- a/apps/sftpgo/config.json
+++ b/apps/sftpgo/config.json
@@ -4,8 +4,9 @@
   "port": 8002,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "sftpgo",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "2.6.5-alpine",
   "categories": ["utilities"],
   "description": "Fully featured and highly configurable SFTP server with optional HTTP/S, FTP/S and WebDAV support - S3, Google Cloud Storage, Azure Blob",
@@ -54,5 +55,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1738965607000
+  "updated_at": 1740331789513
 }

--- a/apps/sftpgo/docker-compose.json
+++ b/apps/sftpgo/docker-compose.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "sftpgo",
+      "image": "drakkan/sftpgo:v2.6.5-alpine",
+      "isMain": true,
+      "internalPort": "${SFTPGO_BINDING_PORT-8080}",
+      "addPorts": [
+        {
+          "hostPort": 2022,
+          "containerPort": 2022
+        }
+      ],
+      "user": "root",
+      "environment": {
+        "SFTPGO_HTTPD__BINDINGS__0__PORT": "${SFTPGO_BINDING_PORT-8080}",
+        "SFTPGO_GRACE_TIME": "${SFTPGO_GRACE_TIME-5}",
+        "SFTPGO_MINIO_SHA256_SIMD": "1",
+        "SFTPGO_DATA_PROVIDER__CREATE_DEFAULT_ADMIN": "${SFTPGO_CREATE_DEFAULT_ADMIN-1}",
+        "SFTPGO_DEFAULT_ADMIN_USERNAME": "${SFTPGO_ADMIN_USERNAME}",
+        "SFTPGO_DEFAULT_ADMIN_PASSWORD": "${SFTPGO_ADMIN_PASSWORD}",
+        "SFTPGO_DATA_PROVIDER__DRIVER": "postgresql",
+        "SFTPGO_DATA_PROVIDER__NAME": "sftpgo",
+        "SFTPGO_DATA_PROVIDER__HOST": "sftpgo-db",
+        "SFTPGO_DATA_PROVIDER__PORT": "5432",
+        "SFTPGO_DATA_PROVIDER__USERNAME": "sftpgo",
+        "SFTPGO_DATA_PROVIDER__PASSWORD": "${SFTPGO_DATABASE_PASSWORD-sftpgo}"
+      },
+      "dependsOn": {
+        "sftpgo-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/var/lib/sftpgo"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/files",
+          "containerPath": "/srv/sftpgo/data"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/backups",
+          "containerPath": "/srv/sftpgo/backups"
+        }
+      ],
+      "healthCheck": {
+        "interval": "30s",
+        "timeout": "5s",
+        "retries": 5,
+        "startPeriod": "30s",
+        "test": "wget --no-verbose --tries=1 --spider http://localhost:${SFTPGO_BINDING_PORT-8080}/healthz"
+      }
+    },
+    {
+      "name": "sftpgo-db",
+      "image": "postgres:17.2-alpine",
+      "environment": {
+        "POSTGRES_PASSWORD": "${SFTPGO_DATABASE_PASSWORD-sftpgo}",
+        "POSTGRES_USER": "sftpgo",
+        "POSTGRES_DB": "sftpgo",
+        "PGUSER": "sftpgo"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready -d sftpgo"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for sftpgo
This is a sftpgo update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://sftpgo.tipi.local
- [x] 🌐 Additionnal Port (2022)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🌆 Uploading data
- [x] 📂 Access through SFTP
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/config:/var/lib/sftpgo
- [x] ${APP_DATA_DIR}/data/files:/srv/sftpgo/data
- [x] ${APP_DATA_DIR}/data/backups:/srv/sftpgo/backups
- [x] ${APP_DATA_DIR}/db:/var/lib/postgresql/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🩺 Healthcheck
- [x] 👤 User (root)
- [x] 🔗 Depends on