### PR TITLE
Add dynamic compose for tubearchivist

### DIFF
--- a/apps/tubearchivist/config.json
+++ b/apps/tubearchivist/config.json
@@ -3,9 +3,10 @@
   "name": "Tube Archivist",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8120,
   "id": "tubearchivist",
-  "tipi_version": 19,
+  "tipi_version": 20,
   "version": "0.4.13",
   "categories": ["media"],
   "description": "Once your YouTube video collection grows, it becomes hard to search and find a specific video. That's where Tube Archivist comes in: By indexing your video collection with metadata from YouTube, you can organize, search and enjoy your archived YouTube videos without hassle offline through a convenient web interface.",
@@ -39,5 +40,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1737276643000
+  "updated_at": 1740331833193
 }

--- a/apps/tubearchivist/docker-compose.json
+++ b/apps/tubearchivist/docker-compose.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "tubearchivist",
+      "image": "bbilly1/tubearchivist:v0.4.13",
+      "isMain": true,
+      "internalPort": 8000,
+      "environment": {
+        "ES_URL": "http://tubearchivist-es:9200",
+        "REDIS_HOST": "tubearchivist-redis",
+        "HOST_UID": "1000",
+        "HOST_GID": "1000",
+        "TA_USERNAME": "${TA_USER}",
+        "TA_PASSWORD": "${TA_PASSWORD}",
+        "TA_HOST": "${APP_DOMAIN}",
+        "ELASTIC_PASSWORD": "${ELASTIC_PASSWORD}"
+      },
+      "dependsOn": ["tubearchivist-es", "tubearchivist-redis"],
+      "volumes": [
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/youtube",
+          "containerPath": "/youtube"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/cache",
+          "containerPath": "/cache"
+        }
+      ]
+    },
+    {
+      "name": "tubearchivist-redis",
+      "image": "redislabs/rejson:latest",
+      "dependsOn": ["tubearchivist-es"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis-data",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "tubearchivist-es",
+      "image": "elasticsearch:8.17.2",
+      "environment": {
+        "xpack.security.enabled": "true",
+        "ELASTIC_PASSWORD": "${ELASTIC_PASSWORD}",
+        "discovery.type": "single-node",
+        "ES_JAVA_OPTS": "-Xms512m -Xmx512m",
+        "path.repo": "/usr/share/elasticsearch/data/snapshot"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/es",
+          "containerPath": "/usr/share/elasticsearch/data"
+        }
+      ],
+      "ulimits": {
+        "memlock": {
+          "soft": -1,
+          "hard": -1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for tubearchivist
This is a tubearchivist update for dynamic compose.
##### Reaching the app :
- [x] http://localip:port
- [x] https://tubearchivist.tipi.local
##### In app tests :
- [x]  📝 Register and log in
- [x]  🎬 Add videos and playlist + subscribe to channel
- [x]  🎞 Download videos
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${ROOT_FOLDER_HOST}/media/data/youtube:/youtube
- [x]  ${APP_DATA_DIR}/data/cache:/cache
- [x]  ${APP_DATA_DIR}/data/redis-data:/data
- [x]  ${APP_DATA_DIR}/data/es:/usr/share/elasticsearch/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🧱 Ulimits
-  🙉 Expose (skipped)
- 🏷 DNS (skipped)