### PR TITLE
Add dynamic compose for zigbee2mqtt

### DIFF
--- a/apps/zigbee2mqtt/config.json
+++ b/apps/zigbee2mqtt/config.json
@@ -4,8 +4,9 @@
   "port": 8290,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "zigbee2mqtt",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "2.1.1",
   "categories": ["utilities", "automation"],
   "description": "Zigbee to MQTT bridge, get rid of your proprietary Zigbee bridges",
@@ -24,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1738877606000
+  "updated_at": 1740331854952
 }

--- a/apps/zigbee2mqtt/docker-compose.json
+++ b/apps/zigbee2mqtt/docker-compose.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "zigbee2mqtt",
+      "image": "koenkk/zigbee2mqtt:2.1.1",
+      "isMain": true,
+      "internalPort": 8080,
+      "environment": {
+        "TZ": "${TZ}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/",
+          "containerPath": "/app/data"
+        }
+      ],
+      "devices": ["${Z2M_DEVICE}:/dev/ttyACM0"]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for zigbee2mqtt
This is a zigbee2mqtt update for dynamic compose
##### Situation tested :
- 💾 Update on existing data
- 👶 Fresh install of the app
##### Reaching the app :
- [x] http://localip:
- [x] https://zigbee2mqtt.tipi.lan
##### In app tests :
- [x] 📝 Modify MQTT setting
- [x]  🖱 Access after succesuful connection to broker
- [x]   💡 Add zigbee device
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/:/app/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 📱 Devices
- 🙉 Expose (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration support, allowing more flexible system adjustments.
	- Updated the service version for compatibility with the latest improvements.
	- Introduced a new containerized deployment setup, simplifying environment variable and device integration for smoother operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->