### PR TITLE
fix: use correct env var in smallweb

### DIFF
--- a/apps/smallweb/config.json
+++ b/apps/smallweb/config.json
@@ -8,7 +8,7 @@
   "port": 7777,
   "categories": ["development"],
   "description": "A self-hostable personal cloud inspired by serverless platforms and cgi-bin",
-  "tipi_version": 20,
+  "tipi_version": 21,
   "version": "0.23.4",
   "source": "https://github.com/pomdtr/smallweb",
   "website": "https://smallweb.run",
@@ -25,5 +25,5 @@
     }
   ],
   "created_at": 1724134338800,
-  "updated_at": 1740711432000
+  "updated_at": 1741190785961
 }

--- a/apps/smallweb/docker-compose.yml
+++ b/apps/smallweb/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ${APP_PORT}:7777
     environment:
       - SMALLWEB_DOMAIN=${SMALLWEB_DOMAIN}
-      - SMALLWEB_CUSTOM_DOMAINS=smallweb.${LOCAL_DOMAIN}=*;${APP_DOMAIN}=*;
+      - SMALLWEB_ADDITIONAL_DOMAINS=smallweb.${LOCAL_DOMAIN}=*;${APP_DOMAIN}=*;
     volumes:
       - ${APP_DATA_DIR}/data/:/smallweb
     networks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated system configuration to reflect the latest version and update timestamp.
	- Renamed a domain-related environment variable for improved clarity in deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->