### PR TITLE
Add dynamic compose for mqttx

### DIFF
--- a/apps/mqttx/config.json
+++ b/apps/mqttx/config.json
@@ -2,9 +2,10 @@
   "name": "MQTTX",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8217,
   "id": "mqttx",
-  "tipi_version": 5,
+  "tipi_version": 6,
   "version": "1.11.1",
   "categories": ["utilities"],
   "description": "MQTTX Web is an open-source MQTT browser client and an online MQTT WebSocket client tool.",
@@ -14,6 +15,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734087570000,
+  "updated_at": 1740331711571,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/mqttx/docker-compose.json
+++ b/apps/mqttx/docker-compose.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "mqttx",
+      "image": "emqx/mqttx-web:v1.11.1",
+      "isMain": true,
+      "internalPort": 80,
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mqttx",
+          "containerPath": "/app/data"
+        },
+        {
+          "hostPath": "/etc/localtime",
+          "containerPath": "/etc/localtime",
+          "readOnly": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for mqttx
##### Reaching the app :
- [x] App reachable as intended
  - [x] http://localip:8217
  - [x] https://mqttx.tipi.lan
##### In app tests :
- [x]  🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data/mqttx:/app/data
- [x] /etc/localtime:/etc/localtime:ro