### PR TITLE
Add dynamic compose for netbootxyz

### DIFF
--- a/apps/netbootxyz/config.json
+++ b/apps/netbootxyz/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8675,
   "exposable": true,
+  "dynamic_config": true,
   "id": "netbootxyz",
   "description": "Your favorite operating systems in one place. A network-based bootable operating system installer based on iPXE.",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "0.7.5-nbxyz3",
   "categories": ["utilities"],
   "short_desc": "Your favorite operating systems in one place.",
@@ -15,6 +16,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1739688863000,
+  "updated_at": 1740331718366,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/netbootxyz/docker-compose.json
+++ b/apps/netbootxyz/docker-compose.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "netbootxyz",
+      "image": "netbootxyz/netbootxyz:0.7.5-nbxyz3",
+      "isMain": true,
+      "internalPort": 3000,
+      "addPorts": [
+        {
+          "hostPort": 69,
+          "containerPort": 69,
+          "udp": true
+        }
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/assets",
+          "containerPath": "/assets"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for netbootxyz
##### Reaching the app :
- [x] http://localip:8675
- [x] https://netbootxyz.tipi.lan
- [x] Additionnals ports (69)
##### In app tests :
- [x]  🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x]  ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/assets:/assets