### PR TITLE
Add dynamic compose for traefik-certs-dumper

### DIFF
--- a/apps/traefik-certs-dumper/config.json
+++ b/apps/traefik-certs-dumper/config.json
@@ -3,10 +3,11 @@
   "name": "Traefik Certs Dumper",
   "available": true,
   "exposable": false,
+  "dynamic_config": true,
   "no_gui": true,
   "port": 9999,
   "id": "traefik-certs-dumper",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "1.6.1",
   "categories": ["utilities", "security"],
   "description": "Dumps Let's Encrypt certificates of a specified domain which Traefik stores in acme.json.",
@@ -16,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1740331818631
 }

--- a/apps/traefik-certs-dumper/docker-compose.json
+++ b/apps/traefik-certs-dumper/docker-compose.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "traefik-certs-dumper",
+      "image": "humenius/traefik-certs-dumper:1.6.1-alpine",
+      "isMain": true,
+      "environment": {
+        "ACME_FILE_PATH": "/traefik/acme.json"
+      },
+      "volumes": [
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/traefik/shared/acme.json",
+          "containerPath": "/traefik/acme.json",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/certs",
+          "containerPath": "/output"
+        }
+      ],
+      "healthCheck": {
+        "interval": "30s",
+        "timeout": "10s",
+        "retries": 5,
+        "test": "/usr/bin/healthcheck"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for traefik-certs-dumper
##### Basic test :
- [x] ✔ App start normally (check logs)
- [x] ⚙Dynamic compose is translated correctly 
##### Volumes mapping verified :
- [x] ${ROOT_FOLDER_HOST}/traefik/shared/acme.json:/traefik/acme.json:ro
- [x] ${APP_DATA_DIR}/data/certs:/output:rw
##### Specific instructions verified :
- [x] 🌳 Environment (ACME_FILE_PATH)
- [x] 🩺 Healthcheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic configuration support with an updated service version for improved operational flexibility.
  - Introduced a new container deployment configuration that streamlines setup with integrated health checks and managed certificate volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->