### PR TITLE
Add dynamic compose for stalwart-mail

### DIFF
--- a/apps/stalwart-mail/config.json
+++ b/apps/stalwart-mail/config.json
@@ -3,7 +3,8 @@
   "name": "Stalwart Mail",
   "available": true,
   "exposable": true,
-  "tipi_version": 26,
+  "dynamic_config": true,
+  "tipi_version": 27,
   "version": "0.11.6",
   "port": 8677,
   "id": "stalwart-mail",
@@ -14,7 +15,14 @@
   "source": "https://github.com/stalwartlabs",
   "website": "https://stalw.art",
   "requirements": {
-    "ports": [25, 143, 465, 587, 993, 4190]
+    "ports": [
+      25,
+      143,
+      465,
+      587,
+      993,
+      4190
+    ]
   },
   "form_fields": [
     {
@@ -26,5 +34,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1738456730000
+  "updated_at": 1742038596509
 }

--- a/apps/stalwart-mail/config.json
+++ b/apps/stalwart-mail/config.json
@@ -15,14 +15,7 @@
   "source": "https://github.com/stalwartlabs",
   "website": "https://stalw.art",
   "requirements": {
-    "ports": [
-      25,
-      143,
-      465,
-      587,
-      993,
-      4190
-    ]
+    "ports": [25, 143, 465, 587, 993, 4190]
   },
   "form_fields": [
     {

--- a/apps/stalwart-mail/docker-compose.json
+++ b/apps/stalwart-mail/docker-compose.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "stalwart-mail",
+      "image": "stalwartlabs/mail-server:v0.11.6",
+      "isMain": true,
+      "internalPort": 8080,
+      "addPorts": [
+        {
+          "hostPort": 25,
+          "containerPort": 25,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        },
+        {
+          "hostPort": 143,
+          "containerPort": 143,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        },
+        {
+          "hostPort": 465,
+          "containerPort": 465,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        },
+        {
+          "hostPort": 587,
+          "containerPort": 587,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        },
+        {
+          "hostPort": 993,
+          "containerPort": 993,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        },
+        {
+          "hostPort": 4190,
+          "containerPort": 4190,
+          "interface": "${NETWORK_INTERFACE:-0.0.0.0}",
+          "tcp": true
+        }
+      ],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/opt/stalwart-mail"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for stalwart-mail
##### Reaching the app :
- [x] http://localip:port
- [x] https://stalwart-mail.tipi.lan
- [x] 🌐 Additionnal Port(s)
##### In app tests :
- [x] 📝 Register and create entries 
- [x] 🔄 Check data after restart
##### Volumes mapping verified :
- [x] ${APP_DATA_DIR}/data:/opt/stalwart-mail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration with enhanced version settings and improved readability for system behavior.
	- Introduced a new container orchestration setup that offers expanded multi-protocol support and persistent data storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->