### PR TITLE
Add dynamic compose for windows

### DIFF
--- a/apps/windows/config.json
+++ b/apps/windows/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8006,
   "exposable": true,
+  "dynamic_config": true,
   "id": "windows",
   "description": "Run windows in docker...because why not?",
-  "tipi_version": 61,
+  "tipi_version": 62,
   "version": "4.21",
   "categories": ["utilities"],
   "short_desc": "Full windows vm in your browser",
@@ -108,7 +109,7 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1741966342000,
+  "updated_at": 1742038621149,
   "$schema": "../app-info-schema.json",
   "force_pull": true
 }

--- a/apps/windows/docker-compose.json
+++ b/apps/windows/docker-compose.json
@@ -27,7 +27,7 @@
         }
       ],
       "sysctls": {
-        "net.ipv4.ip_forward": "1"
+        "net.ipv4.ip_forward": 1
       },
       "devices": ["/dev/kvm"],
       "capAdd": ["NET_ADMIN"],

--- a/apps/windows/docker-compose.json
+++ b/apps/windows/docker-compose.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "windows",
+      "image": "dockurr/windows:4.21",
+      "isMain": true,
+      "internalPort": 8006,
+      "addPorts": [
+        {
+          "hostPort": 3389,
+          "containerPort": 3389,
+          "tcp": true,
+          "udp": true
+        }
+      ],
+      "environment": {
+        "RAM_SIZE": "${WINDOWS_RAM_GB}G",
+        "CPU_CORE": "${WINDOWS_CPU_CORES}",
+        "DISK_SIZE": "${WINDOWS_DISK_SIZE_GB}G",
+        "VERSION": "${WINDOWS_VERSION}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/storage",
+          "containerPath": "/storage"
+        }
+      ],
+      "sysctls": {
+        "net.ipv4.ip_forward": "1"
+      },
+      "devices": ["/dev/kvm"],
+      "capAdd": ["NET_ADMIN"],
+      "stopGracePeriod": "2m"
+    }
+  ]
+}


### PR DESCRIPTION
## Dynamic compose for windows
##### Situtations tested :
- 💾 Update on existing data
- 👶 New install
##### Reaching the app :
- [x] http://localip:port
- [x] https://windows.tipi.local
- [x] Additionnal Port (3389)
##### In app tests :
- [x] 🖥 Choose Windows version
- [x] 🏞 Windows XP obsviously
- [x] 🖱 Basic interaction in the VM
- [x] 🌐 Access internet from VM
- [x] 💻Connect with RDP
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/storage:/storage
##### Specific instructions :
- [x] 🌳 Environment
- [x] 📱 Devices
- [x] 🔓 Capacity add
- [x] 👼 Stop grace period
- [x] ⚙ sysctls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration support with updated versioning and system timestamp.
	- Introduced a new container service configuration for Windows, featuring enhanced resource allocation, port mapping, persistent storage, and smoother shutdown procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->