### PR TITLE
Add dynamic compose for transmission-vpn

### DIFF
--- a/apps/transmission-vpn/config.json
+++ b/apps/transmission-vpn/config.json
@@ -3,9 +3,10 @@
   "name": "Transmission (VPN)",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 9091,
   "id": "transmission-vpn",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "5.3.1",
   "categories": ["utilities", "security"],
   "description": "Transmission is running only when OpenVPN has an active tunnel. It has built-in support for many popular VPN providers to make the setup easier.",
@@ -337,5 +338,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566285000
+  "updated_at": 1742038605230
 }

--- a/apps/transmission-vpn/docker-compose.json
+++ b/apps/transmission-vpn/docker-compose.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "transmission-vpn",
+      "image": "haugene/transmission-openvpn:5.3.1",
+      "isMain": true,
+      "internalPort": 9091,
+      "environment": {
+        "PUID": "${TRANSMISSION_PUID-1000}",
+        "PGID": "${TRANSMISSION_PGID-1000}",
+        "TZ": "${TZ-Europe/Paris}",
+        "USER": "${TRANSMISSION_USERNAME}",
+        "PASS": "${TRANSMISSION_PASSWORD}",
+        "OPENVPN_PROVIDER": "${TRANSMISSION_OVPN_PROVIDER-NORDVPN}",
+        "OPENVPN_CONFIG": "${TRANSMISSION_OVPN_CONFIG}",
+        "OPENVPN_USERNAME": "${TRANSMISSION_OVPN_USERNAME}",
+        "OPENVPN_PASSWORD": "${TRANSMISSION_OVPN_PASSWORD}",
+        "OPENVPN_OPTS": "--inactive 3600 --ping 10 --ping-exit 60 --pull-filter ignore ping",
+        "LOCAL_NETWORK": "${TRANSMISSION_OVPN_LOCAL_NETWORK-10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}",
+        "TRANSMISSION_WEB_UI": "${TRANSMISSION_WEBUI}",
+        "LOG_TO_STDOUT": "true",
+        "GLOBAL_APPLY_PERMISSIONS": "false",
+        "CREATE_TUN_DEVICE": "${TRANSMISSION_CREATE_TUN_DEVICE-false}",
+        "PEER_DNS": "${TRANSMISSION_PEER_DNS-false}",
+        "TRANSMISSION_DOWNLOAD_DIR": "/media/torrents/complete",
+        "TRANSMISSION_INCOMPLETE_DIR_ENABLED": "true",
+        "TRANSMISSION_INCOMPLETE_DIR": "/media/torrents/incomplete",
+        "TRANSMISSION_PREALLOCATION": "1",
+        "TRANSMISSION_DHT_ENABLED": "${TRANSMISSION_DHT_ENABLED-false}",
+        "TRANSMISSION_LPD_ENABLED": "${TRANSMISSION_LPD_ENABLED-false}",
+        "TRANSMISSION_PEX_ENABLED": "${TRANSMISSION_PEX_ENABLED-false}",
+        "TRANSMISSION_BLOCKLIST_ENABLED": "${TRANSMISSION_BLOCKLIST_ENABLED-true}",
+        "TRANSMISSION_BLOCKLIST_URL": "${TRANSMISSION_BLOCKLIST_URL-http://list.iblocklist.com/?list"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/config",
+          "containerPath": "/config"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/custom",
+          "containerPath": "/etc/openvpn/custom"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/torrents",
+          "containerPath": "/media/torrents"
+        }
+      ],
+      "sysctls": {
+        "net.ipv6.conf.all.disable_ipv6": "0"
+      },
+      "devices": ["/dev/net/tun"],
+      "capAdd": ["NET_ADMIN"],
+      "logging": {
+        "driver": "json-file",
+        "options": {
+          "max-size": "10m"
+        }
+      }
+    }
+  ]
+}

--- a/apps/transmission-vpn/docker-compose.json
+++ b/apps/transmission-vpn/docker-compose.json
@@ -31,7 +31,7 @@
         "TRANSMISSION_LPD_ENABLED": "${TRANSMISSION_LPD_ENABLED-false}",
         "TRANSMISSION_PEX_ENABLED": "${TRANSMISSION_PEX_ENABLED-false}",
         "TRANSMISSION_BLOCKLIST_ENABLED": "${TRANSMISSION_BLOCKLIST_ENABLED-true}",
-        "TRANSMISSION_BLOCKLIST_URL": "${TRANSMISSION_BLOCKLIST_URL-http://list.iblocklist.com/?list"
+        "TRANSMISSION_BLOCKLIST_URL": "${TRANSMISSION_BLOCKLIST_URL-http://list.iblocklist.com/?list=bt_level1&fileformat=p2p&archiveformat=gz}"
       },
       "volumes": [
         {
@@ -48,7 +48,7 @@
         }
       ],
       "sysctls": {
-        "net.ipv6.conf.all.disable_ipv6": "0"
+        "net.ipv6.conf.all.disable_ipv6": 0
       },
       "devices": ["/dev/net/tun"],
       "capAdd": ["NET_ADMIN"],


### PR DESCRIPTION
## Dynamic compose for transmission-vpn
##### Basic test :
- [x] ✔ App start normally (check logs)
- [x] ⚙Dynamic compose is translated correctly 
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/config:/config
- [x] ${APP_DATA_DIR}/data/custom:/etc/openvpn/custom
- [x] ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
##### Specific instructions :
- [x] 🌳 Environment
- [x] ⚙ Sysctls
- [x] 📱 Devices
- [x] 🔓 Capacity add
- [x] 📃 Logging
- 🏷 DNS (skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic runtime configuration with an updated version for enhanced flexibility.
  - Introduced a robust Docker deployment configuration, streamlining the setup for the VPN-enabled Transmission application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->