### PR TITLE
Add dynamic compose for nextcloud

### DIFF
--- a/apps/nextcloud/config.json
+++ b/apps/nextcloud/config.json
@@ -3,9 +3,10 @@
   "name": "Nextcloud",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8083,
   "id": "nextcloud",
-  "tipi_version": 23,
+  "tipi_version": 24,
   "version": "26.0.13-apache",
   "categories": ["data"],
   "description": "Nextcloud is a self-hosted, open source, and fully-featured cloud storage solution for your personal files, office documents, and photos.",
@@ -32,5 +33,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1723566283000
+  "updated_at": 1742038546498
 }

--- a/apps/nextcloud/docker-compose.json
+++ b/apps/nextcloud/docker-compose.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "nextcloud",
+      "image": "nextcloud:26.0.13-apache",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "POSTGRES_HOST": "db-nextcloud",
+        "REDIS_HOST": "redis-nextcloud",
+        "POSTGRES_PASSWORD": "tipi",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "nextcloud",
+        "NEXTCLOUD_ADMIN_USER": "${NEXTCLOUD_ADMIN_USER}",
+        "NEXTCLOUD_ADMIN_PASSWORD": "${NEXTCLOUD_ADMIN_PASSWORD}",
+        "NEXTCLOUD_TRUSTED_DOMAINS": "${APP_DOMAIN}",
+        "TRUSTED_PROXIES": "172.16.0.0/12",
+        "OVERWRITEPROTOCOL": "${APP_PROTOCOL:-http}"
+      },
+      "dependsOn": ["db-nextcloud", "redis-nextcloud"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nextcloud",
+          "containerPath": "/var/www/html"
+        }
+      ]
+    },
+    {
+      "name": "db-nextcloud",
+      "image": "postgres:14.2",
+      "environment": {
+        "POSTGRES_PASSWORD": "tipi",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "nextcloud"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/db",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ]
+    },
+    {
+      "name": "redis-nextcloud",
+      "image": "redis:6.2.6",
+      "user": "1000:1000",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ]
+    },
+    {
+      "name": "cron",
+      "image": "nextcloud:25.0.13-apache",
+      "dependsOn": ["db-nextcloud", "redis-nextcloud"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nextcloud",
+          "containerPath": "/var/www/html"
+        }
+      ],
+      "entrypoint": "/cron.sh"
+    }
+  ]
+}

--- a/apps/nextcloud/docker-compose.json
+++ b/apps/nextcloud/docker-compose.json
@@ -24,7 +24,21 @@
           "hostPath": "${APP_DATA_DIR}/data/nextcloud",
           "containerPath": "/var/www/html"
         }
-      ]
+      ],
+      "extraLabels": {
+        "traefik.http.middlewares.nextcloud.headers.browserXSSFilter": "true",
+        "traefik.http.middlewares.nextcloud.headers.contentTypeNosniff": "true",
+        "traefik.http.middlewares.nextcloud.headers.stsIncludeSubdomains": "true",
+        "traefik.http.middlewares.nextcloud.headers.stsPreload": "true",
+        "traefik.http.middlewares.nextcloud.headers.stsSeconds": "155520011",
+        "traefik.http.middlewares.nextcloud_redirect.redirectregex.permanent": "true",
+        "traefik.http.middlewares.nextcloud_redirect.redirectregex.regex": "https://(.*)/.well-known/(card|cal)dav",
+        "traefik.http.middlewares.nextcloud_redirect.redirectregex.replacement": "https://$${1}/remote.php/dav/",
+        "traefik.http.routers.nextcloud.middlewares": "nextcloud,nextcloud_redirect,nextcloud-https",
+        "traefik.http.middlewares.nextcloud.headers.customRequestHeaders.X-Forwarded-Proto": "https",
+        "traefik.http.middlewares.nextcloud-https.redirectscheme.scheme": "https",
+        "traefik.http.routers.nextcloud-http.middlewares": "nextcloud-https@docker"
+      }
     },
     {
       "name": "db-nextcloud",


### PR DESCRIPTION
## Dynamic compose for nextcloud
##### Reaching the app :
- [x] http://localip:port
- [x] https://nextcloud.tipi.local
- [x] https://nextcloud.domain.tld
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🌆 Uploading data
- [x] 🧰 Access through webdav
- [x] ↔ Sync both ways
- [x] 📅 Access CalDav from phone
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/nextcloud:/var/www/html
- [x]  ${APP_DATA_DIR}/data/db:/var/lib/postgresql/data
- [x]  ${APP_DATA_DIR}/data/redis:/data
- [x]  ${APP_DATA_DIR}/data/nextcloud:/var/www/html
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  👤 User (1000:1000)
- [x]  🚪 Entrypoint (/cron.sh)
- [x] 🏷 Extra labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration support along with an updated version.
	- Introduced a container-based deployment option that integrates Nextcloud with its essential services (database, caching, and task scheduling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->