### PR TITLE
Add dynamic compose for penpot

### DIFF
--- a/apps/penpot/config.json
+++ b/apps/penpot/config.json
@@ -3,9 +3,10 @@
   "available": true,
   "port": 8645,
   "exposable": true,
+  "dynamic_config": true,
   "id": "penpot",
   "description": "Penpot - The Open-Source design & prototyping platform.",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "latest",
   "categories": ["utilities"],
   "short_desc": "Open-Source design & prototyping platform.",
@@ -22,7 +23,7 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1740247068576,
+  "updated_at": 1742038570918,
   "$schema": "../app-info-schema.json",
   "force_pull": true
 }

--- a/apps/penpot/docker-compose.json
+++ b/apps/penpot/docker-compose.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "penpot",
+      "image": "penpotapp/frontend:latest",
+      "isMain": true,
+      "internalPort": 80,
+      "environment": {
+        "PENPOT_FLAGS": "enable-registration enable-login-with-password"
+      },
+      "dependsOn": ["penpot-backend", "penpot-exporter"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/assets",
+          "containerPath": "/opt/data/assets"
+        }
+      ]
+    },
+    {
+      "name": "penpot-backend",
+      "image": "penpotapp/backend:latest",
+      "environment": {
+        "PENPOT_FLAGS": "enable-registration enable-login-with-password disable-email-verification",
+        "PENPOT_PUBLIC_URI": "${APP_PROTOCOL:-http}://${APP_DOMAIN}:${APP_PORT}",
+        "PENPOT_DATABASE_URI": "postgresql://penpot-postgres/penpot",
+        "PENPOT_DATABASE_USERNAME": "tipi",
+        "PENPOT_DATABASE_PASSWORD": "${PENPOT_POSTGRES_PASSWORD}",
+        "PENPOT_REDIS_URI": "redis://penpot-redis/0",
+        "PENPOT_ASSETS_STORAGE_BACKEND": "assets-fs",
+        "PENPOT_STORAGE_ASSETS_FS_DIRECTORY": "/opt/data/assets",
+        "PENPOT_TELEMETRY_ENABLED": "false"
+      },
+      "dependsOn": ["penpot-postgres", "penpot-redis"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/assets",
+          "containerPath": "/opt/data/assets"
+        }
+      ]
+    },
+    {
+      "name": "penpot-exporter",
+      "image": "penpotapp/exporter:latest",
+      "environment": {
+        "PENPOT_PUBLIC_URI": "http://penpot",
+        "PENPOT_REDIS_URI": "redis://penpot-redis/0"
+      }
+    },
+    {
+      "name": "penpot-postgres",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_INITDB_ARGS": "--data-checksums",
+        "POSTGRES_DB": "penpot",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${PENPOT_POSTGRES_PASSWORD}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "stopSignal": "SIGINT"
+    },
+    {
+      "name": "penpot-redis",
+      "image": "redis:7"
+    }
+  ]
+}

--- a/apps/penpot/docker-compose.json
+++ b/apps/penpot/docker-compose.json
@@ -5,7 +5,7 @@
       "name": "penpot",
       "image": "penpotapp/frontend:latest",
       "isMain": true,
-      "internalPort": 80,
+      "internalPort": 8080,
       "environment": {
         "PENPOT_FLAGS": "enable-registration enable-login-with-password"
       },
@@ -22,7 +22,7 @@
       "image": "penpotapp/backend:latest",
       "environment": {
         "PENPOT_FLAGS": "enable-registration enable-login-with-password disable-email-verification",
-        "PENPOT_PUBLIC_URI": "${APP_PROTOCOL:-http}://${APP_DOMAIN}:${APP_PORT}",
+        "PENPOT_PUBLIC_URI": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
         "PENPOT_DATABASE_URI": "postgresql://penpot-postgres/penpot",
         "PENPOT_DATABASE_USERNAME": "tipi",
         "PENPOT_DATABASE_PASSWORD": "${PENPOT_POSTGRES_PASSWORD}",


### PR DESCRIPTION
## Dynamic compose for penpot
##### Reaching the app : (fixed)
- [x] http://localip:port
- [x] https://penpot.tipi.lan
##### In app tests :
- [x] 📝 Register and log in
- [x]  🖱 Basic interaction
- [x]  🌆 Uploading data
- [x]  🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/assets:/opt/data/assets
- [x]  ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions :
- [x]  🌳 Environment
- [x]  🔗 Depends on
- [x]  🛑 Stop signal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled a dynamic configuration option and updated versioning to enhance system performance.
  - Introduced a new multi-service deployment setup for improved scalability and streamlined deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->