### PR TITLE
chore: deprecate getashell

### DIFF
--- a/apps/getashell/config.json
+++ b/apps/getashell/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 8281,
   "id": "getashell",
-  "tipi_version": 13,
+  "tipi_version": 14,
   "version": "1.1.3",
   "categories": ["utilities"],
   "description": "Simple web ui to create ssh shells for testing.",
@@ -35,5 +35,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734908260001
+  "updated_at": 1734908260001,
+  "deprecated": true
 }

--- a/apps/getashell/metadata/description.md
+++ b/apps/getashell/metadata/description.md
@@ -1,6 +1,8 @@
 ## Get A Shell 🐚
 
-**Warning ⚠️:** If you are updating to version 1.0.0 make sure to set a username and a password in the settings menu. 
+**warning ⚠️:** This app is no longer maintained and it can be a security risk since it has access to the docker daemon. It is recommended you uninstall it.
+
+**Warning ⚠️:** If you are updating to version 1.0.0 make sure to set a username and a password in the settings menu.
 
 Have you ever wanted to just spin up a quick server than you can ssh into to test something real quick? Well with get a shell
 you can just spin up the ui select a distro and click _Get me a shell!_ and 💥 you have an ssh server with your specified distro. No need to spin up vms, run commands or anything harder than a click!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application's version and marked it as deprecated.
- **Documentation**
	- Revised the warning message to notify users that the app is no longer maintained and may pose security risks, advising uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->