### PR TITLE
Add dynamic compose for logto

### DIFF
--- a/apps/logto/config.json
+++ b/apps/logto/config.json
@@ -4,8 +4,9 @@
   "port": 8203,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "logto",
-  "tipi_version": 29,
+  "tipi_version": 30,
   "version": "1.25.0",
   "force_expose": true,
   "categories": ["security"],
@@ -30,5 +31,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740736593000
+  "updated_at": 1742038511531
 }

--- a/apps/logto/docker-compose.json
+++ b/apps/logto/docker-compose.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "logto",
+      "image": "svhd/logto:1.25.0",
+      "isMain": true,
+      "internalPort": 3001,
+      "addPorts": [
+        {
+          "hostPort": 8204,
+          "containerPort": 3002
+        }
+      ],
+      "environment": {
+        "NODE_ENV": "production",
+        "TRUST_PROXY_HEADER": "1",
+        "DB_URL": "postgres://tipi:${LOGTO_DB_PASSWORD}@logto-db:5432/logto",
+        "ENDPOINT": "https://${APP_DOMAIN}",
+        "ADMIN_ENDPOINT": "https://${LOGTO_ADMIN_URL}"
+      },
+      "dependsOn": {
+        "logto-db": {
+          "condition": "service_healthy"
+        }
+      },
+      "entrypoint": ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
+    },
+    {
+      "name": "logto-db",
+      "image": "postgres:14",
+      "environment": {
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_PASSWORD": "${LOGTO_DB_PASSWORD}",
+        "POSTGRES_DB": "logto"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "healthCheck": {
+        "interval": "10s",
+        "timeout": "5s",
+        "retries": 5,
+        "test": "pg_isready"
+      }
+    }
+  ]
+}

--- a/apps/logto/docker-compose.json
+++ b/apps/logto/docker-compose.json
@@ -24,7 +24,14 @@
           "condition": "service_healthy"
         }
       },
-      "entrypoint": ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
+      "entrypoint": ["sh", "-c", "npm run cli db seed -- --swe && npm start"],
+      "extraLabels": {
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-admin.rule": "Host(`${LOGTO_ADMIN_URL}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-admin.entrypoints": "websecure",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-admin.service": "logto",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-admin.tls.certresolver": "myresolver",
+        "traefik.http.services.{{RUNTIPI_APP_ID}}-admin.loadbalancer.server.port": "3002"
+      }
     },
     {
       "name": "logto-db",


### PR DESCRIPTION
## Dynamic compose for logto
##### Reaching the app :
- [x] http://localip:port
- [x] https://logto.tipi.local
- [x] 🌐 Additionnal Port(s)
- [x] https://admin.logto.tipi.local (traefik label)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🚪 Entrypoint
- [x] 🩺 Healthcheck
- [x] 🏷 Extra labels