### PR TITLE
Add dynamic compose for minio

### DIFF
--- a/apps/minio/config.json
+++ b/apps/minio/config.json
@@ -2,10 +2,11 @@
   "name": "Minio",
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "port": 8001,
   "id": "minio",
   "description": "MinIO is a high-performance, S3 compatible object store. It is built for large scale AI/ML, data lake and database workloads.",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "RELEASE.2025-02-07T23-21-09Z",
   "categories": ["development"],
   "short_desc": "High Performance Object Storage.",
@@ -36,7 +37,7 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740247420440,
+  "updated_at": 1742038537982,
   "$schema": "../app-info-schema.json",
   "force_pull": true
 }

--- a/apps/minio/docker-compose.json
+++ b/apps/minio/docker-compose.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "minio",
+      "image": "minio/minio:RELEASE.2025-02-07T23-21-09Z",
+      "isMain": true,
+      "internalPort": 9001,
+      "addPorts": [
+        {
+          "hostPort": 8000,
+          "containerPort": 9000
+        }
+      ],
+      "environment": {
+        "MINIO_ROOT_USER": "${MINIO_ROOT_USER}",
+        "MINIO_ROOT_PASSWORD": "${MINIO_ROOT_PASSWORD}",
+        "MINIO_BROWSER_REDIRECT_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "MINIO_DOMAIN": "${APP_DOMAIN}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/minio/data",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "server --console-address :9001 /data"
+    }
+  ]
+}

--- a/apps/minio/docker-compose.json
+++ b/apps/minio/docker-compose.json
@@ -24,7 +24,27 @@
           "containerPath": "/data"
         }
       ],
-      "command": "server --console-address :9001 /data"
+      "command": "server --console-address :9001 /data",
+      "extraLabels": {
+        "traefik.http.middlewares.{{RUNTIPI_APP_ID}}-api-web-redirect.redirectscheme.scheme": "https",
+        "traefik.http.services.{{RUNTIPI_APP_ID}}-api.loadbalancer.server.port": "9000",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-insecure.rule": "Host(`${MINIO_API_URL}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-insecure.entrypoints": "web",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-insecure.service": "{{RUNTIPI_APP_ID}}-api",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-insecure.middlewares": "{{RUNTIPI_APP_ID}}-api-web-redirect",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api.rule": "Host(`${MINIO_API_URL}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api.entrypoints": "websecure",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api.service": "{{RUNTIPI_APP_ID}}-api",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api.tls.certresolver": "myresolver",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local-insecure.rule": "Host(`{{RUNTIPI_APP_ID}}-api.${LOCAL_DOMAIN}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local-insecure.entrypoints": "web",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local-insecure.service": "{{RUNTIPI_APP_ID}}-api",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local-insecure.middlewares": "{{RUNTIPI_APP_ID}}-api-web-redirect",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local.rule": "Host(`{{RUNTIPI_APP_ID}}-api.${LOCAL_DOMAIN}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local.entrypoints": "websecure",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local.service": "{{RUNTIPI_APP_ID}}-api",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-api-local.tls": "true"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for minio
##### Reaching the app :
- [x] http://localip:port
- [x] https://minio.tipi.local
- [x] 🌐 Additionnal Port(s)
- [x] https://api.minio.tipi.local (form)
- [x] https://minio-api.tipi.local (extra labels)
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🤖 API Access
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/minio/data:/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] ⌨ Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic configuration for real-time system adjustments.
  - Upgraded the system version with a refreshed release timestamp.
  - Introduced a container-based deployment setup for streamlined object storage service management, offering improved network routing and customizable environment parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->