### PR TITLE
Add dynamic compose for mastodon

### DIFF
--- a/apps/mastodon/config.json
+++ b/apps/mastodon/config.json
@@ -4,10 +4,11 @@
   "port": 8210,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "force_expose": true,
   "generate_vapid_keys": true,
   "id": "mastodon",
-  "tipi_version": 31,
+  "tipi_version": 32,
   "version": "4.3.6",
   "categories": ["social"],
   "description": "Your self-hosted, globally interconnected microblogging community",
@@ -114,5 +115,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1741874765000
+  "updated_at": 1742038518917
 }

--- a/apps/mastodon/docker-compose.json
+++ b/apps/mastodon/docker-compose.json
@@ -6,12 +6,6 @@
       "image": "lscr.io/linuxserver/mastodon:4.3.6",
       "isMain": true,
       "internalPort": 443,
-      "addPorts": [
-        {
-          "hostPort": 8209,
-          "containerPort": 80
-        }
-      ],
       "environment": {
         "PUID": "1000",
         "PGID": "1000",
@@ -57,7 +51,11 @@
           "hostPath": "${APP_DATA_DIR}/data/mastodon-config",
           "containerPath": "/config"
         }
-      ]
+      ],
+      "extraLabels": {
+        "traefik.http.services.mastodon.loadbalancer.serverstransport": "insecuretransport@file",
+        "traefik.http.services.mastodon.loadbalancer.server.scheme": "https"
+      }
     },
     {
       "name": "mastodon-db",
@@ -77,7 +75,7 @@
       ],
       "shmSize": "256mb",
       "healthCheck": {
-        "test": "pg_isready -U tipi"
+        "test": "pg_isready -U tipi -d mastodon"
       }
     },
     {

--- a/apps/mastodon/docker-compose.json
+++ b/apps/mastodon/docker-compose.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "mastodon",
+      "image": "lscr.io/linuxserver/mastodon:4.3.6",
+      "isMain": true,
+      "internalPort": 443,
+      "addPorts": [
+        {
+          "hostPort": 8209,
+          "containerPort": 80
+        }
+      ],
+      "environment": {
+        "PUID": "1000",
+        "PGID": "1000",
+        "TZ": "${TZ}",
+        "LOCAL_DOMAIN": "${MASTODON_LOCAL_DOMAIN}",
+        "WEB_DOMAIN": "${APP_DOMAIN}",
+        "VAPID_PUBLIC_KEY": "${VAPID_PUBLIC_KEY}",
+        "VAPID_PRIVATE_KEY": "${VAPID_PRIVATE_KEY}",
+        "REDIS_HOST": "mastodon-redis",
+        "REDIS_PASSWORD": "${MASTODON_REDIS_PASSWORD}",
+        "REDIS_PORT": "6379",
+        "DB_HOST": "mastodon-db",
+        "DB_USER": "tipi",
+        "DB_NAME": "mastodon",
+        "DB_PASS": "${MASTODON_POSTGRES_PASSWORD}",
+        "DB_PORT": "5432",
+        "ES_ENABLED": "false",
+        "SECRET_KEY_BASE": "${MASTODON_SECRET_KEY_BASE}",
+        "OTP_SECRET": "${MASTODON_OTP_SECRET}",
+        "SMTP_SERVER": "${MASTODON_SMTP_SERVER}",
+        "SMTP_PORT": "${MASTODON_SMTP_PORT}",
+        "SMTP_LOGIN": "${MASTODON_SMTP_LOGIN}",
+        "SMTP_PASSWORD": "${MASTODON_SMTP_PASSWORD}",
+        "SMTP_FROM_ADDRESS": "${MASTODON_SMTP_FROM_ADDRESS}",
+        "S3_ENABLED": "false",
+        "SIDEKIQ_ONLY": "false",
+        "SIDEKIQ_DEFAULT": "false",
+        "SIDEKIQ_THREADS": "5",
+        "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY": "${MASTODON_ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY}",
+        "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT": "${MASTODON_ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT}",
+        "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY": "${MASTODON_ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY}"
+      },
+      "dependsOn": {
+        "mastodon-db": {
+          "condition": "service_healthy"
+        },
+        "mastodon-redis": {
+          "condition": "service_healthy"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mastodon-config",
+          "containerPath": "/config"
+        }
+      ]
+    },
+    {
+      "name": "mastodon-db",
+      "image": "postgres:14-alpine",
+      "environment": {
+        "POSTGRES_PASSWORD": "${MASTODON_POSTGRES_PASSWORD}",
+        "POSTGRES_USER": "tipi",
+        "POSTGRES_DB": "mastodon",
+        "PG_DATA": "/var/lib/postgresql/data",
+        "POSTGRES_HOST_AUTH_METHODL": "trust"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/postgres",
+          "containerPath": "/var/lib/postgresql/data"
+        }
+      ],
+      "shmSize": "256mb",
+      "healthCheck": {
+        "test": "pg_isready -U tipi"
+      }
+    },
+    {
+      "name": "mastodon-redis",
+      "image": "redis:7-alpine",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/redis",
+          "containerPath": "/data"
+        }
+      ],
+      "command": "redis-server --appendonly yes --replica-read-only no --requirepass \"${MASTODON_REDIS_PASSWORD}\"",
+      "healthCheck": {
+        "test": "redis-cli ping"
+      }
+    }
+  ]
+}

--- a/apps/mastodon/docker-compose.json
+++ b/apps/mastodon/docker-compose.json
@@ -65,7 +65,7 @@
         "POSTGRES_USER": "tipi",
         "POSTGRES_DB": "mastodon",
         "PG_DATA": "/var/lib/postgresql/data",
-        "POSTGRES_HOST_AUTH_METHODL": "trust"
+        "POSTGRES_HOST_AUTH_METHOD": "trust"
       },
       "volumes": [
         {

--- a/apps/mastodon/docker-compose.json
+++ b/apps/mastodon/docker-compose.json
@@ -53,8 +53,8 @@
         }
       ],
       "extraLabels": {
-        "traefik.http.services.mastodon.loadbalancer.serverstransport": "insecuretransport@file",
-        "traefik.http.services.mastodon.loadbalancer.server.scheme": "https"
+        "traefik.http.services.{{RUNTIPI_APP_ID}}.loadbalancer.serverstransport": "insecuretransport@file",
+        "traefik.http.services.{{RUNTIPI_APP_ID}}.loadbalancer.server.scheme": "https"
       }
     },
     {


### PR DESCRIPTION
## Dynamic compose for mastodon
##### Reaching the app :
- [x] http://localip:port (yes but need domain)
- [x] https://mastodon.tipi.local (yes but need domain)
- [x] https://mastodon.domain.com
-  Additionnal Port 80 removed
##### In app tests :
- [x] 🐚 Create account from CLI
- [x] 📝 Log in with mobile app and web UI
- [x] 🖱 Basic interaction
- [x] 🌆 Uploading images in post
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/mastodon-config:/config
- [x] ${APP_DATA_DIR}/data/postgres:/var/lib/postgresql/data
- [x] ${APP_DATA_DIR}/data/redis:/data
##### Specific instructions :
- [x] 🌳 Environment
- [x] 🔗 Depends on
- [x] 🩺 Healthcheck (fixed)
- [x] 🧠 Shared memory size(256mb)
- [x] ⌨ Command
- [x] 🏷 Extra labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic configuration for improved flexibility.
  - Introduced a containerized deployment setup integrating essential services for seamless Mastodon operations.
  - Added health checks for database and caching services to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->