### PR TITLE
Add dynamic compose for smallweb

### DIFF
--- a/apps/smallweb/config.json
+++ b/apps/smallweb/config.json
@@ -8,11 +8,12 @@
   "port": 7777,
   "categories": ["development"],
   "description": "A self-hostable personal cloud inspired by serverless platforms and cgi-bin",
-  "tipi_version": 25,
+  "tipi_version": 26,
   "version": "0.24.8",
   "source": "https://github.com/pomdtr/smallweb",
   "website": "https://smallweb.run",
   "exposable": true,
+  "dynamic_config": true,
   "supported_architectures": ["arm64", "amd64"],
   "form_fields": [
     {
@@ -25,5 +26,5 @@
     }
   ],
   "created_at": 1724134338800,
-  "updated_at": 1741817738000
+  "updated_at": 1742038588717
 }

--- a/apps/smallweb/docker-compose.json
+++ b/apps/smallweb/docker-compose.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "smallweb",
+      "image": "ghcr.io/pomdtr/smallweb:0.24.8",
+      "isMain": true,
+      "internalPort": 7777,
+      "user": "0:0",
+      "environment": {
+        "SMALLWEB_DOMAIN": "${SMALLWEB_DOMAIN}",
+        "SMALLWEB_ADDITIONAL_DOMAINS": "smallweb.${LOCAL_DOMAIN};${APP_DOMAIN}"
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/",
+          "containerPath": "/smallweb"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/smallweb/docker-compose.json
+++ b/apps/smallweb/docker-compose.json
@@ -16,7 +16,17 @@
           "hostPath": "${APP_DATA_DIR}/data/",
           "containerPath": "/smallweb"
         }
-      ]
+      ],
+      "traefikOverrides": {
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-insecure.rule": "Host(`${APP_DOMAIN}`) || HostRegexp(`.+\\.${APP_DOMAIN}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}.rule": "Host(`${APP_DOMAIN}`) || HostRegexp(`.+\\.${APP_DOMAIN}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-local-insecure.rule": "Host(`{{RUNTIPI_APP_ID}}.${LOCAL_DOMAIN}`) || HostRegexp(`.+\\.{{RUNTIPI_APP_ID}}\\.${LOCAL_DOMAIN}`)",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}-local.rule": "Host(`{{RUNTIPI_APP_ID}}.${LOCAL_DOMAIN}`) || HostRegexp(`.+\\.{{RUNTIPI_APP_ID}}\\.${LOCAL_DOMAIN}`)"
+      },
+      "extraLabels": {
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}.tls.domains[0].main": "${APP_DOMAIN}",
+        "traefik.http.routers.{{RUNTIPI_APP_ID}}.tls.domains[0].sans": "*.${APP_DOMAIN}"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Dynamic compose for smallweb
##### Reaching the app :
- [x] http://localip:port
- [x] https://smallweb.tipi.local (redirect to www)
- [x] https://www.smallweb.tipi.local
- [x] https://test.smallweb.tipi.local
##### In app tests :
- [x] 📝Create additional website
- [x] 🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x] ${APP_DATA_DIR}/data/:/smallweb
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (0:0)
- [x] 🏷 Extra labels
- [x] 🔖 Override labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration settings with an upgraded service version and new dynamic options.
  - Introduced a refreshed deployment setup offering streamlined domain management, secure routing, and persistent data support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->