### PR TITLE
Add dynamic compose for invoice ninja & rollback to v5.10.62

### DIFF
--- a/apps/invoice-ninja/config.json
+++ b/apps/invoice-ninja/config.json
@@ -4,8 +4,9 @@
   "port": 8881,
   "available": true,
   "exposable": true,
+  "dynamic_config": true,
   "id": "invoice-ninja",
-  "tipi_version": 83,
+  "tipi_version": 84,
   "version": "5.11.55",
   "categories": ["finance"],
   "description": "Invoice Ninja is an invoicing application which makes sending invoices and receiving payments simple and easy. Our latest version is a clean slate rewrite of our popular invoicing application which builds on the existing feature set and adds a wide range of features and enhancements the community has asked for.",
@@ -46,5 +47,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1742007076000
+  "updated_at": 1742038504086
 }

--- a/apps/invoice-ninja/config.json
+++ b/apps/invoice-ninja/config.json
@@ -7,7 +7,7 @@
   "dynamic_config": true,
   "id": "invoice-ninja",
   "tipi_version": 84,
-  "version": "5.11.55",
+  "version": "5.10.62",
   "categories": ["finance"],
   "description": "Invoice Ninja is an invoicing application which makes sending invoices and receiving payments simple and easy. Our latest version is a clean slate rewrite of our popular invoicing application which builds on the existing feature set and adds a wide range of features and enhancements the community has asked for.",
   "short_desc": "Invoices, Expenses and Tasks built with Laravel, Flutter and React.",

--- a/apps/invoice-ninja/docker-compose.json
+++ b/apps/invoice-ninja/docker-compose.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "invoice-ninja",
+      "image": "invoiceninja/invoiceninja:5.11.55",
+      "isMain": true,
+      "user": "1500:1500",
+      "environment": {
+        "IN_USER_EMAIL": "${INVOICE_NINJA_USER_MAIL}",
+        "IN_PASSWORD": "${INVOICE_NINJA_USER_PASSWORD}",
+        "APP_URL": "http://invoice-ninja-web",
+        "APP_NAME": "\"Invoice Ninja\"",
+        "APP_ENV": "production",
+        "APP_KEY": "${INVOICE_NINJA_APP_KEY}",
+        "APP_CIPHER": "AES-256-CBC",
+        "DB_HOST": "invoice-ninja-db",
+        "DB_PORT": "3306",
+        "DB_DATABASE": "ninja",
+        "DB_USERNAME": "ninja",
+        "DB_PASSWORD": "ninja",
+        "REQUIRE_HTTPS": "false",
+        "QUEUE_CONNECTION": "database",
+        "IS_DOCKER": "TRUE"
+      },
+      "dependsOn": ["invoice-ninja-db"],
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/public",
+          "containerPath": "/var/www/app/public"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/storage",
+          "containerPath": "/var/www/app/storage"
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/php/php.ini",
+          "containerPath": "/usr/local/etc/php/php.ini",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/php/php-cli.ini",
+          "containerPath": "/usr/local/etc/php/php-cli.ini",
+          "readOnly": true
+        }
+      ]
+    },
+    {
+      "name": "invoice-ninja-web",
+      "image": "nginx:1.27",
+      "internalPort": 80,
+      "dependsOn": {
+        "invoice-ninja": {
+          "condition": "service_started"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/nginx/invoice-ninja.conf",
+          "containerPath": "/etc/nginx/conf.d/default.conf",
+          "readOnly": true
+        },
+        {
+          "hostPath": "${APP_DATA_DIR}/data/public",
+          "containerPath": "/var/www/app/public",
+          "readOnly": true
+        }
+      ]
+    },
+    {
+      "name": "invoice-ninja-db",
+      "image": "mariadb:10.7",
+      "environment": {
+        "MARIADB_ROOT_PASSWORD": "${INVOICE_NINJA_BDD_PASSWORD}",
+        "MARIADB_USER": "ninja",
+        "MARIADB_PASSWORD": "ninja",
+        "MARIADB_DATABASE": "ninja"
+      },
+      "dependsOn": {
+        "invoice-ninja-init": {
+          "condition": "service_completed_successfully"
+        }
+      },
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data/mysql",
+          "containerPath": "/var/lib/mysql"
+        }
+      ],
+      "command": ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--wait_timeout=28800", "--log-warnings=0"]
+    },
+    {
+      "name": "invoice-ninja-init",
+      "image": "bash:5.2.37",
+      "volumes": [
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/tmp/data"
+        }
+      ],
+      "command": "bash -c \"chmod +x /tmp/data/init/init.sh && /tmp/data/init/init.sh \""
+    }
+  ]
+}

--- a/apps/invoice-ninja/docker-compose.json
+++ b/apps/invoice-ninja/docker-compose.json
@@ -3,14 +3,13 @@
   "services": [
     {
       "name": "invoice-ninja",
-      "image": "invoiceninja/invoiceninja:5.11.55",
-      "isMain": true,
+      "image": "invoiceninja/invoiceninja:5.10.62", 
       "user": "1500:1500",
       "environment": {
         "IN_USER_EMAIL": "${INVOICE_NINJA_USER_MAIL}",
         "IN_PASSWORD": "${INVOICE_NINJA_USER_PASSWORD}",
-        "APP_URL": "http://invoice-ninja-web",
-        "APP_NAME": "\"Invoice Ninja\"",
+        "APP_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}",
+        "APP_NAME": "Invoice Ninja",
         "APP_ENV": "production",
         "APP_KEY": "${INVOICE_NINJA_APP_KEY}",
         "APP_CIPHER": "AES-256-CBC",
@@ -48,6 +47,7 @@
     {
       "name": "invoice-ninja-web",
       "image": "nginx:1.27",
+      "isMain": true,
       "internalPort": 80,
       "dependsOn": {
         "invoice-ninja": {
@@ -76,29 +76,12 @@
         "MARIADB_PASSWORD": "ninja",
         "MARIADB_DATABASE": "ninja"
       },
-      "dependsOn": {
-        "invoice-ninja-init": {
-          "condition": "service_completed_successfully"
-        }
-      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/mysql",
           "containerPath": "/var/lib/mysql"
         }
-      ],
-      "command": ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--wait_timeout=28800", "--log-warnings=0"]
-    },
-    {
-      "name": "invoice-ninja-init",
-      "image": "bash:5.2.37",
-      "volumes": [
-        {
-          "hostPath": "${APP_DATA_DIR}/data",
-          "containerPath": "/tmp/data"
-        }
-      ],
-      "command": "bash -c \"chmod +x /tmp/data/init/init.sh && /tmp/data/init/init.sh \""
+      ]
     }
   ]
 }

--- a/apps/invoice-ninja/docker-compose.json
+++ b/apps/invoice-ninja/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "invoice-ninja",
-      "image": "invoiceninja/invoiceninja:5.10.62", 
+      "image": "invoiceninja/invoiceninja:5.10.62",
       "user": "1500:1500",
       "environment": {
         "IN_USER_EMAIL": "${INVOICE_NINJA_USER_MAIL}",

--- a/apps/invoice-ninja/docker-compose.yml
+++ b/apps/invoice-ninja/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   invoice-ninja:
-    image: invoiceninja/invoiceninja:5.11.55
+    image: invoiceninja/invoiceninja:5.10.62
     container_name: invoice-ninja
     restart: unless-stopped
     user: 1500:1500


### PR DESCRIPTION
## Dynamic compose for invoice-ninja + Rollback version
##### Reaching the app :
- [x]  http://localip:port
- [x]  https://invoice-ninja.tipi.local
##### In app tests :
- [x] 📝 Register and log in
- [x] 🖱 Basic interaction
- [x] 🔄 Check data after restart
##### Volumes mapping :
- [x]  ${APP_DATA_DIR}/data/public:/var/www/app/public:rw,delegated
- [x]  ${APP_DATA_DIR}/data/storage:/var/www/app/storage:rw,delegated
- [x]  ${APP_DATA_DIR}/data/php/php.ini:/usr/local/etc/php/php.ini:ro
- [x]  ${APP_DATA_DIR}/data/php/php-cli.ini:/usr/local/etc/php/php-cli.ini:ro
- [x]  ${APP_DATA_DIR}/data/nginx/invoice-ninja.conf:/etc/nginx/conf.d/default.conf:ro
- [x]  ${APP_DATA_DIR}/data/public:/var/www/app/public:ro
- [x]  ${APP_DATA_DIR}/data/mysql:/var/lib/mysql:rw,delegated
##### Specific instructions :
- [x]  🌳 Environment
- [x]  👤 User (1500:1500)
- [x]  🔗 Depends on
- [x]  ⌨ Command

## Additionnal notes
App version has been rollback to `v5.10`
Version `5.11` have issues resulting in Error 502 in NGINX

**This app need a rework to be updated further than `v5.10.62`**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled dynamic configuration support for smoother application adjustments.
	- Introduced a complete containerized deployment setup integrating the application interface, web service, and database.
- **Chores**
	- Updated application versioning to maintain consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->