### PR TITLE
Fix app : SearXNG (access through domain name)

### DIFF
--- a/apps/searxng/config.json
+++ b/apps/searxng/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 8127,
   "id": "searxng",
-  "tipi_version": 7,
+  "tipi_version": 8,
   "version": "latest",
   "categories": ["social"],
   "description": "SearXNG is a free internet metasearch engine which aggregates results from various search services and databases. Users are neither tracked nor profiled.",

--- a/apps/searxng/config.json
+++ b/apps/searxng/config.json
@@ -23,6 +23,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740247068576,
+  "updated_at": 1744197771100,
   "force_pull": true
 }

--- a/apps/searxng/docker-compose.json
+++ b/apps/searxng/docker-compose.json
@@ -6,7 +6,6 @@
       "isMain": true,
       "internalPort": 8080,
       "environment": {
-        "BIND_ADDRESS": "0.0.0.0:8080",
         "BASE_URL": "${APP_PROTOCOL:-http}://${APP_DOMAIN}/",
         "SEARXNG_SECRET": "${SEARXNG_SECRET_KEY}"
       },


### PR DESCRIPTION
> BIND ADDRESS variable has been removed.

This was causing since issues since the `v3.16` release of SearXNG.
May be linked to the default IPv6 implementation : https://github.com/searxng/searxng/pull/4448

You will be able to access through external URL and local domain again.
