### PR TITLE
Fix Outline dynamic compose

### DIFF
--- a/apps/outline/config.json
+++ b/apps/outline/config.json
@@ -7,7 +7,7 @@
   "port": 8404,
   "categories": ["utilities"],
   "description": "Outline is a knowledge base designed for teams. It's goals are to be fast, intuitive and support many integrations.",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "version": "0.83.0",
   "source": "https://github.com/outline/outline",
   "website": "https://getoutline.com",
@@ -69,6 +69,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1744354973000,
+  "updated_at": 1745399212000,
   "$schema": "../app-info-schema.json"
 }

--- a/apps/outline/docker-compose.json
+++ b/apps/outline/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "outline",
-      "image": "outlinewiki/outline:0.82.0",
+      "image": "outlinewiki/outline:0.83.0",
       "environment": {
         "DATABASE_URL": "postgres://outline:${OUTLINE_PG_PASSWORD}@outline-postgres:5432/outline",
         "REDIS_URL": "redis://outline-redis:6379",
@@ -82,7 +82,7 @@
     },
     {
       "name": "outline-nginx",
-      "image": "outlinewiki/outline:0.83.0",
+      "image": "nginx:alpine",
       "isMain": true,
       "internalPort": 80,
       "dependsOn": ["outline", "outline-oidc"],


### PR DESCRIPTION
A recent renovate update _replaced_ the `nginx:alpine` docker image with outline's causing it to fail to start. This PR fixes the problem.