### PR TITLE
Update docker-compose.yml

### DIFF
--- a/apps/komga/docker-compose.yml
+++ b/apps/komga/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${APP_DATA_DIR}/data/data:/data
+      - ${ROOT_FOLDER_HOST}/media/data/books:/books
+      - ${ROOT_FOLDER_HOST}/media/data/comics:/comics
+      - ${ROOT_FOLDER_HOST}/media/data/manga:/manga
     environment:
       - TZ=${TZ}
     ports:


### PR DESCRIPTION
Was missing the volume paths so it couldn't connect to the other runtipi apps like kapowarr, and mylar.  Now it should be able to grab your files from the media path like it should.   (Matches how the Kavita app does it)