### PR TITLE
Komga: add media directory

### DIFF
--- a/apps/komga/config.json
+++ b/apps/komga/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "komga",
-  "tipi_version": 21,
+  "tipi_version": 22,
   "version": "1.21.2",
   "categories": ["media"],
   "description": "A media server for your comics, mangas, BDs, magazines and eBooks.",
@@ -17,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1741757291000
+  "updated_at": 1746360860860
 }

--- a/apps/komga/docker-compose.json
+++ b/apps/komga/docker-compose.json
@@ -16,6 +16,10 @@
         {
           "hostPath": "${APP_DATA_DIR}/data/data",
           "containerPath": "/data"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media",
+          "containerPath": "/media"
         }
       ]
     }

--- a/apps/komga/docker-compose.yml
+++ b/apps/komga/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
       - ${APP_DATA_DIR}/data/data:/data
+      - ${ROOT_FOLDER_HOST}/media:/media
     environment:
       - TZ=${TZ}
     ports:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration version and timestamp for the Komga app.
- **New Features**
  - Added a new volume mount for media files in the Komga Docker Compose setup, allowing access to a /media directory within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->