### PR TITLE
Scrypted: remove default mapped devices

### DIFF
--- a/apps/scrypted/docker-compose.json
+++ b/apps/scrypted/docker-compose.json
@@ -21,7 +21,6 @@
         }
       ],
       "privileged": true,
-      "devices": ["/dev/bus/usb:/dev/bus/usb", "/dev/dri:/dev/dri"],
       "logging": {
         "driver": "json-file",
         "options": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker Compose configuration by removing USB and DRI device mappings from the service setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->