### PR TITLE
fix(pihole): rename environment variable that changed in v6

### DIFF
--- a/apps/pihole/config.json
+++ b/apps/pihole/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 8081,
   "id": "pihole",
-  "tipi_version": 24,
+  "tipi_version": 25,
   "version": "2025.04.0",
   "url_suffix": "/admin",
   "categories": ["network", "security"],
@@ -32,6 +32,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1743848515000,
+  "updated_at": 1746804427000,
   "force_pull": false
 }

--- a/apps/pihole/docker-compose.json
+++ b/apps/pihole/docker-compose.json
@@ -18,7 +18,7 @@
       "hostname": "pihole",
       "environment": {
         "TZ": "${TZ}",
-        "WEBPASSWORD": "${APP_PASSWORD}"
+        "FTLCONF_webserver_api_password": "${APP_PASSWORD}"
       },
       "volumes": [
         {

--- a/apps/pihole/docker-compose.yml
+++ b/apps/pihole/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ${APP_DATA_DIR}/data/dnsmasq:/etc/dnsmasq.d
     environment:
       TZ: ${TZ}
-      WEBPASSWORD: ${APP_PASSWORD}
+      FTLCONF_webserver_api_password: ${APP_PASSWORD}
     cap_add:
       - NET_ADMIN
     networks:


### PR DESCRIPTION
The `WEBPASSWORD` environment variable is now named `FTLCONF_webserver_api_password` and new installs are broken due to this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the environment variable name for the Pi-hole web password in the service configuration. No changes to functionality or password value.
  - Incremented the Pi-hole configuration version and updated the timestamp metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->