### PR TITLE
fix(crafty): invalid port range on dynamic compose

### DIFF
--- a/apps/crafty/config.json
+++ b/apps/crafty/config.json
@@ -7,7 +7,7 @@
   "port": 8456,
   "id": "crafty",
   "https": true,
-  "tipi_version": 14,
+  "tipi_version": 15,
   "version": "4.4.7",
   "categories": ["gaming"],
   "description": "Crafty 4 is the next iteration of our Minecraft Server Wrapper / Controller / Launcher.",
@@ -18,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1737393502000
+  "updated_at": 1746895169000
 }

--- a/apps/crafty/docker-compose.json
+++ b/apps/crafty/docker-compose.json
@@ -42,8 +42,8 @@
           "udp": true
         },
         {
-          "hostPort": "25500-25510",
-          "containerPort": "25500-25510"
+          "hostPort": "25500-25600",
+          "containerPort": "25500-25600"
         }
       ]
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Expanded the port range for the "crafty" service to support ports 25500–25600 in the docker-compose configuration.
  - Updated the Crafty app configuration to a new platform version and refreshed the last updated timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->