### PR TITLE
Forgejo: update to v11

### DIFF
--- a/apps/forgejo/config.json
+++ b/apps/forgejo/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "forgejo",
-  "tipi_version": 19,
-  "version": "1.21.11-0",
+  "tipi_version": 20,
+  "version": "11.0.1",
   "categories": ["development"],
   "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.",
   "short_desc": "Beyond coding. We forge. · Lightweight and performant · Guaranteed 100% Free Software",
@@ -23,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1736624608519
+  "updated_at": 1747323599999
 }

--- a/apps/forgejo/docker-compose.json
+++ b/apps/forgejo/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "forgejo",
-      "image": "codeberg.org/forgejo/forgejo:1.21.11-0",
+      "image": "codeberg.org/forgejo/forgejo:11.0.1",
       "isMain": true,
       "internalPort": 3000,
       "addPorts": [

--- a/apps/forgejo/docker-compose.yml
+++ b/apps/forgejo/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:1.21.11-0
+    image: codeberg.org/forgejo/forgejo:11.0.1
     container_name: forgejo
     environment:
       - USER_UID=1000


### PR DESCRIPTION
Naming scheme for Forgejo versions has changed a we were a few major versions behind.

The upgrade is handled by the app without any issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Forgejo app configuration and Docker Compose files to use version 11.0.1.
  - Refreshed metadata and timestamps to reflect the latest update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->