### PR TITLE
updating open-webui from 0.6.5 to 0.6.9

### DIFF
--- a/apps/open-webui/config.json
+++ b/apps/open-webui/config.json
@@ -6,7 +6,7 @@
   "port": 8536,
   "id": "open-webui",
   "tipi_version": 58,
-  "version": "0.6.5",
+  "version": "0.6.9",
   "categories": ["ai"],
   "description": "Open WebUI is an extensible, feature-rich, and user-friendly self-hosted WebUI designed to operate entirely offline.",
   "short_desc": "User-friendly WebUI for LLMs",

--- a/apps/open-webui/docker-compose.json
+++ b/apps/open-webui/docker-compose.json
@@ -1,7 +1,7 @@
 {
   "services": [
     {
-      "image": "ghcr.io/open-webui/open-webui:v0.6.5",
+      "image": "ghcr.io/open-webui/open-webui:v0.6.9",
       "name": "open-webui",
       "internalPort": 8080,
       "isMain": true,

--- a/apps/open-webui/docker-compose.yml
+++ b/apps/open-webui/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.6.5
+    image: ghcr.io/open-webui/open-webui:v0.6.9
     container_name: open-webui
     volumes:
       - ${APP_DATA_DIR}/data:/app/backend/data


### PR DESCRIPTION
updating open-webui from 0.6.5 to 0.6.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated version references from 0.6.5 to 0.6.9 in configuration and Docker Compose files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->