### PR TITLE
Update paperless-ngx to 2.16.2

### DIFF
--- a/apps/paperless-ngx/config.json
+++ b/apps/paperless-ngx/config.json
@@ -7,7 +7,7 @@
   "port": 8012,
   "id": "paperless-ngx",
   "tipi_version": 66,
-  "version": "2.15.3",
+  "version": "2.16.2",
   "categories": ["utilities"],
   "description": "Paperless-ngx is a community-supported open-source document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.",
   "short_desc": "Document Management System (DMS)",
@@ -52,5 +52,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1746359209444
+  "updated_at": 1748196682400
 }

--- a/apps/paperless-ngx/docker-compose.json
+++ b/apps/paperless-ngx/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "paperless-ngx",
-      "image": "ghcr.io/paperless-ngx/paperless-ngx:2.15.3",
+      "image": "ghcr.io/paperless-ngx/paperless-ngx:2.16.2",
       "isMain": true,
       "internalPort": 8000,
       "environment": {

--- a/apps/paperless-ngx/docker-compose.yml
+++ b/apps/paperless-ngx/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   paperless-ngx:
     container_name: paperless-ngx
-    image: ghcr.io/paperless-ngx/paperless-ngx:2.15.3
+    image: ghcr.io/paperless-ngx/paperless-ngx:2.16.2
     restart: unless-stopped
     depends_on:
       - db


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Paperless-ngx to version 2.16.2 in configuration and deployment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->