### PR TITLE
eclipse-mosquitto: fix typo during auto update

### DIFF
--- a/apps/eclipse-mosquitto/docker-compose.json
+++ b/apps/eclipse-mosquitto/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "eclipse-mosquitto",
-      "image": "eclipse-mosquitto:2.0.20",
+      "image": "eclipse-mosquitto:2.0.21",
       "command": ["/dynsec-setup.sh", "/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"],
       "environment": {
         "TZ": "${TZ}",
@@ -33,7 +33,7 @@
     },
     {
       "name": "mosquitto-management-center",
-      "image": "eclipse-mosquitto:2.0.21",
+      "image": "cedalo/management-center:2",
       "environment": {
         "TZ": "${TZ}",
         "CEDALO_MC_BROKER_ID": "mosquitto-broker",


### PR DESCRIPTION
PR  #7030  updated the incorrect field in the docker-compose.json file for the migration of eclipse-mosquitto to version 2.0.21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Mosquitto service to use version 2.0.21.
  - Changed the management center service to use the latest Cedalo Management Center image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->