### PR TITLE
chore(obsidian-livesync): update 3.1.2 → 3.5.0 (minor)

### DIFF
--- a/apps/obsidian-livesync/config.json
+++ b/apps/obsidian-livesync/config.json
@@ -7,8 +7,8 @@
   "dynamic_config": true,
   "no_gui": true,
   "id": "obsidian-livesync",
-  "tipi_version": 2,
-  "version": "3.1.2",
+  "tipi_version": 3,
+  "version": "3.5.0",
   "categories": ["utilities"],
   "description": "LiveSync couchdb backend for Obsidian",
   "short_desc": "LiveSync couchdb backend for Obsidian",
@@ -43,5 +43,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1733761005578
+  "updated_at": 1748523398374
 }

--- a/apps/obsidian-livesync/docker-compose.json
+++ b/apps/obsidian-livesync/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "obsidian-livesync",
-      "image": "couchdb:3.1.2",
+      "image": "couchdb:3.5.0",
       "isMain": true,
       "internalPort": 5984,
       "environment": {

--- a/apps/obsidian-livesync/docker-compose.yml
+++ b/apps/obsidian-livesync/docker-compose.yml
@@ -1,9 +1,8 @@
 version: '3.7'
-
 services:
   obsidian-livesync:
     container_name: obsidian-livesync
-    image: couchdb:3.1.2
+    image: couchdb:3.5.0
     ports:
       - ${OBSIDIAN_LIVESYNC_PORT:-${APP_PORT}}:5984
     environment:
@@ -15,27 +14,22 @@ services:
     networks:
       - tipi_main_network
     labels:
-      # Main
       traefik.enable: true
       traefik.http.middlewares.obsidian-livesync-web-redirect.redirectscheme.scheme: https
       traefik.http.services.obsidian-livesync.loadbalancer.passhostheader: true
       traefik.http.services.obsidian-livesync.loadbalancer.server.port: 5984
-      # Web
       traefik.http.routers.obsidian-livesync-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.obsidian-livesync-insecure.entrypoints: web
       traefik.http.routers.obsidian-livesync-insecure.service: obsidian-livesync
       traefik.http.routers.obsidian-livesync-insecure.middlewares: obsidian-livesync-web-redirect
-      # Websecure
       traefik.http.routers.obsidian-livesync.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.obsidian-livesync.entrypoints: websecure
       traefik.http.routers.obsidian-livesync.service: obsidian-livesync
       traefik.http.routers.obsidian-livesync.tls.certresolver: myresolver
-      # Local domain
       traefik.http.routers.obsidian-livesync-local-insecure.rule: Host(`obsidian-livesync.${LOCAL_DOMAIN}`)
       traefik.http.routers.obsidian-livesync-local-insecure.entrypoints: web
       traefik.http.routers.obsidian-livesync-local-insecure.service: obsidian-livesync
       traefik.http.routers.obsidian-livesync-local-insecure.middlewares: obsidian-livesync-web-redirect
-      # Local domain secure
       traefik.http.routers.obsidian-livesync-local.rule: Host(`obsidian-livesync.${LOCAL_DOMAIN}`)
       traefik.http.routers.obsidian-livesync-local.entrypoints: websecure
       traefik.http.routers.obsidian-livesync-local.service: obsidian-livesync


### PR DESCRIPTION
## Docker Image Updates

- obsidian-livesync: `couchdb:3.1.2` → `couchdb:3.5.0` (minor)
- obsidian-livesync: `couchdb:3.1.2` → `couchdb:3.5.0` (minor)
