### PR TITLE
chore(logto): update 1.26.0 → 1.28.0 (minor)

### DIFF
--- a/apps/logto/config.json
+++ b/apps/logto/config.json
@@ -31,5 +31,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748547429025
+  "updated_at": 1748547734251
 }


### PR DESCRIPTION
## Docker Image Updates

- logto: `svhd/logto:1.26.0` → `svhd/logto:1.28.0` (minor)
- logto: `svhd/logto:1.26.0` → `svhd/logto:1.28.0` (minor)
