### PR TITLE
chore(paperless-ngx): update 2.16.2 → 2.16.2 (minor)

### DIFF
--- a/apps/paperless-ngx/config.json
+++ b/apps/paperless-ngx/config.json
@@ -6,11 +6,9 @@
   "dynamic_config": true,
   "port": 8012,
   "id": "paperless-ngx",
-  "tipi_version": 67,
+  "tipi_version": 68,
   "version": "2.16.2",
-  "categories": [
-    "utilities"
-  ],
+  "categories": ["utilities"],
   "description": "Paperless-ngx is a community-supported open-source document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.",
   "short_desc": "Document Management System (DMS)",
   "author": "Daniel Quinn, Jonas Winkler, and the Paperless-ngx team",
@@ -52,10 +50,7 @@
       "env_variable": "PAPERLESS_TIKA_ENABLED"
     }
   ],
-  "supported_architectures": [
-    "arm64",
-    "amd64"
-  ],
+  "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748514352718
+  "updated_at": 1748547880837
 }

--- a/apps/paperless-ngx/docker-compose.json
+++ b/apps/paperless-ngx/docker-compose.json
@@ -17,10 +17,7 @@
         "COMPOSE_PROJECT_NAME": "paperless-ngx",
         "PAPERLESS_CSRF_TRUSTED_ORIGINS": "https://${APP_ID}.${LOCAL_DOMAIN},https://${APP_DOMAIN},http://${INTERNAL_IP}:${APP_PORT}"
       },
-      "dependsOn": [
-        "db",
-        "broker"
-      ],
+      "dependsOn": ["db", "broker"],
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/paperless_data",
@@ -68,11 +65,7 @@
     {
       "name": "gotenberg",
       "image": "gotenberg/gotenberg:8.21",
-      "command": [
-        "gotenberg",
-        "--chromium-disable-javascript=true",
-        "--chromium-allow-list=file:///tmp/.*"
-      ]
+      "command": ["gotenberg", "--chromium-disable-javascript=true", "--chromium-allow-list=file:///tmp/.*"]
     },
     {
       "name": "tika",

--- a/apps/paperless-ngx/docker-compose.yml
+++ b/apps/paperless-ngx/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: '3.7'
 services:
   paperless-ngx:
     container_name: paperless-ngx
@@ -28,37 +28,26 @@ services:
     networks:
       - tipi_main_network
     labels:
-      # Main
       traefik.enable: true
       traefik.http.middlewares.paperless-ngx-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.paperless-ngx.loadbalancer.server.port:
-        8000
-        # Web
+      traefik.http.services.paperless-ngx.loadbalancer.server.port: 8000
       traefik.http.routers.paperless-ngx-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.paperless-ngx-insecure.entrypoints: web
       traefik.http.routers.paperless-ngx-insecure.service: paperless-ngx
-      traefik.http.routers.paperless-ngx-insecure.middlewares:
-        paperless-ngx-web-redirect
-        # Websecure
+      traefik.http.routers.paperless-ngx-insecure.middlewares: paperless-ngx-web-redirect
       traefik.http.routers.paperless-ngx.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.paperless-ngx.entrypoints: websecure
       traefik.http.routers.paperless-ngx.service: paperless-ngx
-      traefik.http.routers.paperless-ngx.tls.certresolver:
-        myresolver
-        # Local domain
+      traefik.http.routers.paperless-ngx.tls.certresolver: myresolver
       traefik.http.routers.paperless-ngx-local-insecure.rule: Host(`paperless-ngx.${LOCAL_DOMAIN}`)
       traefik.http.routers.paperless-ngx-local-insecure.entrypoints: web
       traefik.http.routers.paperless-ngx-local-insecure.service: paperless-ngx
-      traefik.http.routers.paperless-ngx-local-insecure.middlewares:
-        paperless-ngx-web-redirect
-        # Local domain secure
+      traefik.http.routers.paperless-ngx-local-insecure.middlewares: paperless-ngx-web-redirect
       traefik.http.routers.paperless-ngx-local.rule: Host(`paperless-ngx.${LOCAL_DOMAIN}`)
       traefik.http.routers.paperless-ngx-local.entrypoints: websecure
       traefik.http.routers.paperless-ngx-local.service: paperless-ngx
       traefik.http.routers.paperless-ngx-local.tls: true
       runtipi.managed: true
-
-  # Redis
   broker:
     image: redis:7
     restart: unless-stopped
@@ -82,14 +71,12 @@ services:
     labels:
       runtipi.managed: true
   gotenberg:
-    image: gotenberg/gotenberg:8.20
+    image: gotenberg/gotenberg:8.21
     restart: unless-stopped
-    # The gotenberg chromium route is used to convert .eml files. We do not
-    # want to allow external content like tracking pixels or even javascript.
     command:
-      - "gotenberg"
-      - "--chromium-disable-javascript=true"
-      - "--chromium-allow-list=file:///tmp/.*"
+      - gotenberg
+      - '--chromium-disable-javascript=true'
+      - '--chromium-allow-list=file:///tmp/.*'
     networks:
       - tipi_main_network
     labels:


### PR DESCRIPTION
## Docker Image Updates

- gotenberg: `gotenberg/gotenberg:8.20` → `gotenberg/gotenberg:8.21` (minor)
