### PR TITLE
Immich : change DB image to 

### DIFF
--- a/apps/immich/config.json
+++ b/apps/immich/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 8128,
   "id": "immich",
-  "tipi_version": 132,
+  "tipi_version": 133,
   "version": "1.134.0",
   "categories": ["data", "photography"],
   "description": "Photo and video backup solution directly from your mobile phone.",
@@ -36,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748547749653
+  "updated_at": 1748552858540
 }

--- a/apps/immich/docker-compose.json
+++ b/apps/immich/docker-compose.json
@@ -56,7 +56,7 @@
     },
     {
       "name": "immich-db",
-      "image": "tensorchord/pgvecto-rs:pg14-v0.4.0",
+      "image": "ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0",
       "environment": {
         "POSTGRES_PASSWORD": "${DB_PASSWORD}",
         "POSTGRES_USER": "tipi",
@@ -68,27 +68,7 @@
           "hostPath": "${APP_DATA_DIR}/data/db",
           "containerPath": "/var/lib/postgresql/data"
         }
-      ],
-      "command": [
-        "postgres",
-        "-c",
-        "shared_preload_libraries=vectors.so",
-        "-c",
-        "search_path=\"$$user\", public, vectors",
-        "-c",
-        "logging_collector=on",
-        "-c",
-        "max_wal_size=2GB",
-        "-c",
-        "shared_buffers=512MB",
-        "-c",
-        "wal_compression=on"
-      ],
-      "healthCheck": {
-        "interval": "5m",
-        "startPeriod": "5m",
-        "test": "pg_isready --dbname=\"$$POSTGRES_DB\" --username=\"$$POSTGRES_USER\" || exit 1; Chksum=\"$$(psql --dbname=\"$$POSTGRES_DB\" --username=\"$$POSTGRES_USER\" --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')\"; echo \"checksum failure count is $$Chksum\"; [ \"$$Chksum\" = '0' ] || exit 1"
-      }
+      ]
     }
   ]
 }

--- a/apps/immich/docker-compose.yml
+++ b/apps/immich/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       runtipi.managed: true
   immich-db:
     container_name: immich-db
-    image: tensorchord/pgvecto-rs:pg14-v0.4.0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: tipi
@@ -86,24 +86,5 @@ services:
     restart: unless-stopped
     networks:
       - tipi_main_network
-    healthcheck:
-      test: pg_isready --dbname='${DB_DATABASE_NAME}' || exit 1; Chksum="$$(psql --dbname='${DB_DATABASE_NAME}' --username='${DB_USERNAME}' --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')"; echo "checksum failure count is $$Chksum"; [ "$$Chksum" = '0' ] || exit 1
-      interval: 5m
-      start_interval: 30s
-      start_period: 5m
-    command:
-      - postgres
-      - '-c'
-      - shared_preload_libraries=vectors.so
-      - '-c'
-      - search_path="$$user", public, vectors
-      - '-c'
-      - logging_collector=on
-      - '-c'
-      - max_wal_size=2GB
-      - '-c'
-      - shared_buffers=512MB
-      - '-c'
-      - wal_compression=on
     labels:
       runtipi.managed: true


### PR DESCRIPTION
Addressing the breaking change introduced with [v0.133](https://github.com/immich-app/immich/releases/tag/v1.133.0) :

Image used is now : **ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0**
`healtcheck` and `command` instructions are not necessary anymore.
