### PR TITLE
chore(notemark): update 0.15.4 → 0.16.0 (minor)

### DIFF
--- a/apps/notemark/config.json
+++ b/apps/notemark/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8567,
   "id": "notemark",
-  "tipi_version": 23,
-  "version": "0.15.4",
+  "tipi_version": 24,
+  "version": "0.16.0",
   "categories": ["utilities"],
   "description": "Note Mark is a lighting fast and minimal web-based Markdown notes app.",
   "short_desc": "Lighting fast web-based Markdown notes app.",
@@ -23,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748545621796
+  "updated_at": 1748622274148
 }

--- a/apps/notemark/docker-compose.json
+++ b/apps/notemark/docker-compose.json
@@ -2,11 +2,11 @@
   "services": [
     {
       "name": "notemark",
-      "image": "ghcr.io/enchant97/note-mark-frontend:0.15.4"
+      "image": "ghcr.io/enchant97/note-mark-frontend:0.16.0"
     },
     {
       "name": "notemark-backend",
-      "image": "ghcr.io/enchant97/note-mark-backend:0.15.4",
+      "image": "ghcr.io/enchant97/note-mark-backend:0.16.0",
       "environment": {
         "JWT_SECRET": "${NOTEMARK_SERVICE_SECRET}",
         "CORS_ORIGINS": "*"

--- a/apps/notemark/docker-compose.yml
+++ b/apps/notemark/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   notemark:
-    image: ghcr.io/enchant97/note-mark-frontend:0.15.4
+    image: ghcr.io/enchant97/note-mark-frontend:0.16.0
     container_name: notemark
     restart: unless-stopped
     networks:
@@ -9,7 +9,7 @@ services:
     labels:
       runtipi.managed: true
   notemark-backend:
-    image: ghcr.io/enchant97/note-mark-backend:0.15.4
+    image: ghcr.io/enchant97/note-mark-backend:0.16.0
     container_name: notemark-backend
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Docker Image Updates

- notemark: `ghcr.io/enchant97/note-mark-frontend:0.15.4` → `ghcr.io/enchant97/note-mark-frontend:0.16.0` (minor)
- notemark-backend: `ghcr.io/enchant97/note-mark-backend:0.15.4` → `ghcr.io/enchant97/note-mark-backend:0.16.0` (minor)
- notemark: `ghcr.io/enchant97/note-mark-frontend:0.15.4` → `ghcr.io/enchant97/note-mark-frontend:0.16.0` (minor)
- notemark: `ghcr.io/enchant97/note-mark-frontend:0.15.4` → `ghcr.io/enchant97/note-mark-frontend:0.16.0` (minor)
- notemark-backend: `ghcr.io/enchant97/note-mark-backend:0.15.4` → `ghcr.io/enchant97/note-mark-backend:0.16.0` (minor)
