### PR TITLE
chore(notemark): update 0.16.0 → 0.16.0 (minor)

### DIFF
--- a/apps/notemark/config.json
+++ b/apps/notemark/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "port": 8567,
   "id": "notemark",
-  "tipi_version": 24,
+  "tipi_version": 25,
   "version": "0.16.0",
   "categories": ["utilities"],
   "description": "Note Mark is a lighting fast and minimal web-based Markdown notes app.",
@@ -23,5 +23,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748622274148
+  "updated_at": 1748623684435
 }

--- a/apps/notemark/docker-compose.json
+++ b/apps/notemark/docker-compose.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "notemark-proxy",
-      "image": "ghcr.io/enchant97/note-mark-frontend:0.15.4",
+      "image": "ghcr.io/enchant97/note-mark-frontend:0.16.0",
       "isMain": true,
       "internalPort": 80,
       "volumes": [

--- a/apps/notemark/docker-compose.yml
+++ b/apps/notemark/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       runtipi.managed: true
   notemark-proxy:
     container_name: notemark-proxy
-    image: nginx:alpine
+    image: ghcr.io/enchant97/note-mark-frontend:0.16.0
     ports:
       - ${APP_PORT}:80
     volumes:


### PR DESCRIPTION
## Docker Image Updates

- notemark-proxy: `ghcr.io/enchant97/note-mark-frontend:0.15.4` → `ghcr.io/enchant97/note-mark-frontend:0.16.0` (minor)
