### PR TITLE
Librephotos update to version 2025w24

### DIFF
--- a/apps/librephotos/config.json
+++ b/apps/librephotos/config.json
@@ -7,7 +7,7 @@
   "dynamic_config": true,
   "id": "librephotos",
   "tipi_version": 16,
-  "version": "2023w48",
+  "version": "2025w24",
   "categories": ["photography"],
   "description": "Complete photo management service",
   "short_desc": "Complete photo management service",
@@ -49,6 +49,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1740247420440,
+  "updated_at": 1751519618000,
   "force_pull": false
 }

--- a/apps/librephotos/docker-compose.json
+++ b/apps/librephotos/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "librephotos",
-      "image": "reallibrephotos/librephotos-proxy:2023w48",
+      "image": "reallibrephotos/librephotos-proxy:2025w24",
       "isMain": true,
       "internalPort": 80,
       "dependsOn": ["librephotos-backend", "librephotos-frontend"],
@@ -45,12 +45,12 @@
     },
     {
       "name": "librephotos-frontend",
-      "image": "reallibrephotos/librephotos-frontend:2023w48",
+      "image": "reallibrephotos/librephotos-frontend:2025w24",
       "dependsOn": ["librephotos-backend"]
     },
     {
       "name": "librephotos-backend",
-      "image": "reallibrephotos/librephotos:2023w48",
+      "image": "reallibrephotos/librephotos:2025w24",
       "environment": {
         "SECRET_KEY": "${LIBREPHOTOS_SECRET_KEY}",
         "BACKEND_HOST": "librephotos-backend",

--- a/apps/librephotos/docker-compose.yml
+++ b/apps/librephotos/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   librephotos:
-    image: reallibrephotos/librephotos-proxy:2023w48
+    image: reallibrephotos/librephotos-proxy:2025w24
     container_name: librephotos
     restart: unless-stopped
     volumes:
@@ -62,7 +62,7 @@ services:
     labels:
       runtipi.managed: true
   librephotos-frontend:
-    image: reallibrephotos/librephotos-frontend:2023w48
+    image: reallibrephotos/librephotos-frontend:2025w24
     container_name: librephotos-frontend
     restart: unless-stopped
     depends_on:
@@ -72,7 +72,7 @@ services:
     labels:
       runtipi.managed: true
   librephotos-backend:
-    image: reallibrephotos/librephotos:2023w48
+    image: reallibrephotos/librephotos:2025w24
     container_name: librephotos-backend
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Bumped version of LibrePhotos from 2023w48 to 2025w24
Tested on my own runtipi instance and seems to work flawlessly. 