### PR TITLE
Update firefly-iii and fix schema error

### DIFF
--- a/apps/firefly-iii-data-importer/config.json
+++ b/apps/firefly-iii-data-importer/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "dynamic_config": true,
   "port": 8150,
-  "tipi_version": 9,
-  "version": "version-1.7.10",
+  "tipi_version": 10,
+  "version": "version-1.8.4",
   "id": "firefly-iii-data-importer",
   "categories": ["finance"],
   "description": "",
@@ -36,6 +36,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1757000855555,
+  "updated_at": 1760650400000,
   "force_pull": false
 }

--- a/apps/firefly-iii-data-importer/docker-compose.json
+++ b/apps/firefly-iii-data-importer/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "firefly-iii-data-importer",
-      "image": "fireflyiii/data-importer:version-1.7.10",
+      "image": "fireflyiii/data-importer:version-1.8.4",
       "isMain": true,
       "internalPort": 8080,
       "environment": {

--- a/apps/firefly-iii-data-importer/docker-compose.yml
+++ b/apps/firefly-iii-data-importer/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   firefly-iii-data-importer:
-    image: fireflyiii/data-importer:version-1.7.10
+    image: fireflyiii/data-importer:version-1.8.4
     container_name: firefly-iii-data-importer
     restart: unless-stopped
     ports:

--- a/apps/firefly-iii/config.json
+++ b/apps/firefly-iii/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "dynamic_config": true,
   "port": 8115,
-  "tipi_version": 12,
-  "version": "6.3.2",
+  "tipi_version": 13,
+  "version": "6.4.2",
   "id": "firefly-iii",
   "categories": ["finance"],
   "description": "",
@@ -45,6 +45,6 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1757000855555,
+  "updated_at": 1760650400000,
   "force_pull": false
 }

--- a/apps/firefly-iii/docker-compose.json
+++ b/apps/firefly-iii/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "firefly-iii",
-      "image": "fireflyiii/core:version-6.3.2",
+      "image": "fireflyiii/core:version-6.4.2",
       "isMain": true,
       "internalPort": 8080,
       "environment": {

--- a/apps/firefly-iii/docker-compose.yml
+++ b/apps/firefly-iii/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   firefly-iii:
-    image: fireflyiii/core:version-6.3.2
+    image: fireflyiii/core:version-6.4.2
     container_name: firefly-iii
     restart: unless-stopped
     volumes:

--- a/apps/matrix-conduit/config.json
+++ b/apps/matrix-conduit/config.json
@@ -8,7 +8,7 @@
   "force_expose": true,
   "no_gui": true,
   "id": "matrix-conduit",
-  "tipi_version": 10,
+  "tipi_version": 11,
   "version": "0.10.3",
   "categories": ["social"],
   "description": "Conduit is a fast Matrix homeserver that’s easy to set up and just works. You can install it on a mini-computer like the Raspberry Pi to host Matrix for your family, friends or company.",
@@ -72,5 +72,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748521776912
+  "updated_at": 1760650400000
 }

--- a/apps/navidrome/config.json
+++ b/apps/navidrome/config.json
@@ -6,7 +6,7 @@
   "dynamic_config": true,
   "id": "navidrome",
   "description": "Modern Music Server and Streamer compatible with Subsonic/Airsonic",
-  "tipi_version": 29,
+  "tipi_version": 30,
   "version": "0.58.0",
   "categories": ["media", "music"],
   "short_desc": "A selfhosted music server",
@@ -15,6 +15,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1753851562630,
+  "updated_at": 1760650400000,
   "$schema": "../app-info-schema.json"
 }


### PR DESCRIPTION
Bump tipi version for :
navidrome
matrix-conduit
firefly-iii
firefly-iii-data-importer

These app were previously using empty environment variables but weren't updated.
This was mandatory to comply with the new dynamic-compose schema version.