### PR TITLE
Fix a change in the data storage location of Stalwart

### DIFF
--- a/apps/stalwart-mail/docker-compose.json
+++ b/apps/stalwart-mail/docker-compose.json
@@ -48,7 +48,7 @@
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",
-          "containerPath": "/opt/stalwart-mail"
+          "containerPath": "/opt/stalwart"
         }
       ]
     }

--- a/apps/stalwart-mail/docker-compose.yml
+++ b/apps/stalwart-mail/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/stalwartlabs/stalwart:v0.14.0
     container_name: stalwart-mail
     volumes:
-      - ${APP_DATA_DIR}/data:/opt/stalwart-mail
+      - ${APP_DATA_DIR}/data:/opt/stalwart
     restart: unless-stopped
     networks:
       - tipi_main_network


### PR DESCRIPTION
Stalwart seems to have changed the persistant data storage location within the container from `/opt/stalwart-mail` to `/opt/stalwart`. 

This breaks Stalwart, causing all data and configuration to be lost upon restart of the container.