### PR TITLE
Update placeholder path in config.json

### DIFF
--- a/apps/mempool/config.json
+++ b/apps/mempool/config.json
@@ -22,7 +22,7 @@
       "type": "text",
       "label": "Custom Bitcoin data folder location (for .cookie file)",
       "hint": "Default, tipi bitcoin folder",
-      "placeholder": "/home/user/runtipi/app-data/bitcoind/data",
+      "placeholder": "/home/<user>/runtipi/app-data/<appstore>/bitcoind/data",
       "required": true,
       "env_variable": "BITCOIND_DIR"
     },


### PR DESCRIPTION
I got a little tripped up with this one, I added angle brackets to make it clear that these need to be replaced.

I think other valid solutions would be:

1. Make this field NOT mandatory.
2. replace <appstore> with `migrated`.

I think maybe number 1 is the best option, but I just wanted to raise this PR to see how contributing to this project works.