### PR TITLE
Set Firefly III to auto update on 6.x

### DIFF
--- a/apps/firefly-iii/config.json
+++ b/apps/firefly-iii/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "dynamic_config": true,
   "port": 8115,
-  "tipi_version": 16,
-  "version": "6.4.16",
+  "tipi_version": 17,
+  "version": "version-6",
   "id": "firefly-iii",
   "categories": ["finance"],
   "description": "",
@@ -46,6 +46,6 @@
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
   "updated_at": 1761338378464,
-  "force_pull": false,
+  "force_pull": true,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/firefly-iii/docker-compose.json
+++ b/apps/firefly-iii/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "firefly-iii",
-      "image": "fireflyiii/core:version-6.4.16",
+      "image": "fireflyiii/core:version-6",
       "isMain": true,
       "internalPort": 8080,
       "environment": [

--- a/apps/firefly-iii/docker-compose.yml
+++ b/apps/firefly-iii/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   firefly-iii:
-    image: fireflyiii/core:version-6.4.16
+    image: fireflyiii/core:version-6
     container_name: firefly-iii
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Hello! I've noticed updates are sometimes a bit slow to be picked up for Firefly III. Firefly III updates quite often so it can be hard to keep up manually. This PR sets the image to `version-6` and `force_pull: true` so the image is always updated to the latest 6.x on restart.