### PR TITLE
fix(atuin): update atuin startup command to match change from v18.12.0

### DIFF
--- a/apps/atuin/docker-compose.json
+++ b/apps/atuin/docker-compose.json
@@ -7,7 +7,7 @@
       "name": "atuin",
       "internalPort": 8888,
       "isMain": true,
-      "command": "server start",
+      "command": "start",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data/config",

--- a/apps/atuin/docker-compose.yml
+++ b/apps/atuin/docker-compose.yml
@@ -1,10 +1,10 @@
-version: '3.5'
+version: "3.5"
 services:
   atuin:
     container_name: atuin
     restart: unless-stopped
     image: ghcr.io/atuinsh/atuin:v18.12.0
-    command: server start
+    command: start
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
     ports:


### PR DESCRIPTION
Atuin v18.12.0 changes the command from `server start` to just `start`.

https://github.com/atuinsh/atuin/releases/tag/v18.12.0