### PR TITLE
remove condition for version setting in config.json

### DIFF
--- a/scripts/update-config.ts
+++ b/scripts/update-config.ts
@@ -39,7 +39,6 @@ const updateAppConfig = async (packageFile: string, newVersion: string) => {
     const packageRoot = path.dirname(packageFile);
     const configPath = path.join(packageRoot, "config.json");
     const dockerComposeYmlPath = path.join(packageRoot, "docker-compose.yml");
-    const dockerComposeJsonPath = path.join(packageRoot, "docker-compose.json");
 
     const config = await readJsonFile<AppInfo>(configPath);
     const dockerComposeYml = await readYamlFile<DockerComposeYml>(dockerComposeYmlPath);


### PR DESCRIPTION
This kinda revert #8274

The condition was preventing a correct versioning in config.json for apps where :
- the actual app is not the "main" service _(like invoice-ninja)_
- image version tag contains a suffix/prefix  _(like ollama-amd)_