### PR TITLE
fix: set downloads volume to container expected value

### DIFF
--- a/apps/transmission/docker-compose.yml
+++ b/apps/transmission/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - PASS=${TRANSMISSION_PASSWORD}
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      - ${ROOT_FOLDER_HOST}/media/torrents:/media/torrents
+      - ${ROOT_FOLDER_HOST}/media/torrents:/downloads
     ports:
       - ${APP_PORT}:9091
       - '51413:51413'


### PR DESCRIPTION
The [`linuxserver/transmission`](https://hub.docker.com/r/linuxserver/transmission) image is expecting the downloads directory to be `/downloads`.

Currently, it is set to `/media/torrents` inside the container.

This PR binds the host directory `${ROOT_FOLDER_HOST}/media/torrents` to the expected `/downloads` directory.