### PR TITLE
Update fireshare app with image mountpoint

### DIFF
--- a/apps/fireshare/config.json
+++ b/apps/fireshare/config.json
@@ -8,7 +8,7 @@
   "id": "fireshare",
   "tipi_version": 44,
   "version": "1.6.1",
-  "categories": ["development"],
+  "categories": ["gaming", "development"],
   "description": "Self host your media and share with unique links. Share your game clips, videos, or other media via unique links.",
   "short_desc": "Self host your media and share with unique links",
   "author": "https://github.com/ShaneIsrael",

--- a/apps/fireshare/config.json
+++ b/apps/fireshare/config.json
@@ -6,7 +6,7 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fireshare",
-  "tipi_version": 44,
+  "tipi_version": 45,
   "version": "1.6.1",
   "categories": ["gaming", "media"],
   "description": "Self host your media and share with unique links. Share your game clips, videos, or other media via unique links.",

--- a/apps/fireshare/config.json
+++ b/apps/fireshare/config.json
@@ -8,7 +8,7 @@
   "id": "fireshare",
   "tipi_version": 44,
   "version": "1.6.1",
-  "categories": ["gaming", "development"],
+  "categories": ["gaming", "media"],
   "description": "Self host your media and share with unique links. Share your game clips, videos, or other media via unique links.",
   "short_desc": "Self host your media and share with unique links",
   "author": "https://github.com/ShaneIsrael",

--- a/apps/fireshare/docker-compose.json
+++ b/apps/fireshare/docker-compose.json
@@ -43,6 +43,10 @@
         {
           "hostPath": "${ROOT_FOLDER_HOST}/media/data/videos/fireshare_videos",
           "containerPath": "/videos"
+        },
+        {
+          "hostPath": "${ROOT_FOLDER_HOST}/media/data/images/fireshare_images",
+          "containerPath": "/images"
         }
       ]
     }

--- a/apps/fireshare/docker-compose.yml
+++ b/apps/fireshare/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ${APP_DATA_DIR}/data/fireshare_data:/data
       - ${APP_DATA_DIR}/data/fireshare_processed:/processed
       - ${ROOT_FOLDER_HOST}/media/data/videos/fireshare_videos:/videos
+      - ${ROOT_FOLDER_HOST}/media/data/images/fireshare_images:/images
     environment:
       - ADMIN_USERNAME=${FIRESHARE_USERNAME}
       - ADMIN_PASSWORD=${FIRESHARE_PASSWORD}

--- a/apps/fireshare/metadata/description.md
+++ b/apps/fireshare/metadata/description.md
@@ -7,6 +7,7 @@
 | /runtipi/app-data/fireshare/data/fireshare_data      | /data            |
 | /runtipi/app-data/fireshare/data/fireshare_processed | /processed       |
 | /runtipi/media/data/videos/fireshare_videos          | /videos          |
+| /runtipi/media/data/images/fireshare_images          | /images          |
 
 ---
 


### PR DESCRIPTION
Fireshare added the ability to host images as well as videos by mounting an `/images` directory. This pull request adds that mountpoint to the Runtipi appstore version.