### PR TITLE
fix: update Cyberchef's internal port to 8080

### DIFF
--- a/apps/cyberchef/config.json
+++ b/apps/cyberchef/config.json
@@ -9,12 +9,12 @@
   "port": 9080,
   "categories": ["utilities", "security"],
   "description": "CyberChef is a web app for encryption, encoding, compression, and data analysis.",
-  "tipi_version": 23,
+  "tipi_version": 24,
   "version": "11.3.0",
   "source": "https://github.com/gchq/CyberChef",
-  "supported_architectures": ["amd64"],
+  "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1785139087114,
+  "updated_at": 1785576773931,
   "$schema": "../app-info-schema.json",
   "min_tipi_version": "4.5.0"
 }

--- a/apps/cyberchef/docker-compose.json
+++ b/apps/cyberchef/docker-compose.json
@@ -4,7 +4,7 @@
       "name": "cyberchef",
       "image": "ghcr.io/gchq/cyberchef:11.3.0",
       "isMain": true,
-      "internalPort": 80,
+      "internalPort": 8080,
       "environment": [
         {
           "key": "TZ",

--- a/apps/cyberchef/docker-compose.yml
+++ b/apps/cyberchef/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     environment:
       - TZ=${TZ}
     ports:
-      - ${APP_PORT}:80
+      - ${APP_PORT}:8080
     networks:
       - tipi_main_network
     labels:
       traefik.enable: true
       traefik.http.middlewares.cyberchef-web-redirect.redirectscheme.scheme: https
-      traefik.http.services.cyberchef.loadbalancer.server.port: 80
+      traefik.http.services.cyberchef.loadbalancer.server.port: 8080
       traefik.http.routers.cyberchef-insecure.rule: Host(`${APP_DOMAIN}`)
       traefik.http.routers.cyberchef-insecure.entrypoints: web
       traefik.http.routers.cyberchef-insecure.service: cyberchef


### PR DESCRIPTION
A user in the Discord server reported [1] that since `v11.0.0` Cyberchef has changed its default port from `80` to `8080`. This PR resolves the issue by updating the compose files.

**Note to reviewers:** I have not verified the changes in this PR, please review extra carefully and optionally test the changes!

[1]: https://discord.com/channels/976934649643294750/976934650104676448/1533015796920488026
