### PR TITLE
siyuan: add serve subcommand to fix container startup

### DIFF
--- a/apps/siyuan/config.json
+++ b/apps/siyuan/config.json
@@ -8,7 +8,7 @@
   "port": 6806,
   "categories": ["utilities"],
   "description": "SiYuan is a privacy-first personal knowledge management system, support fine-grained block-level reference and Markdown WYSIWYG.",
-  "tipi_version": 72,
+  "tipi_version": 73,
   "version": "v3.7.3",
   "website": "https://b3log.org/siyuan/en/",
   "source": "https://github.com/siyuan-note/siyuan",
@@ -29,6 +29,6 @@
   "uid": 1000,
   "gid": 1000,
   "created_at": 1691943801422,
-  "updated_at": 1784702780349,
+  "updated_at": 1785688245000,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/siyuan/docker-compose.json
+++ b/apps/siyuan/docker-compose.json
@@ -25,7 +25,7 @@
           "containerPath": "/siyuan/workspace/"
         }
       ],
-      "command": ["--workspace=/siyuan/workspace/", "--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}"]
+      "command": ["serve", "--workspace=/siyuan/workspace/", "--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}"]
     }
   ],
   "schemaVersion": 2,

--- a/apps/siyuan/docker-compose.yml
+++ b/apps/siyuan/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: b3log/siyuan:v3.7.3
     container_name: siyuan
     command:
+      - serve
       - '--workspace=/siyuan/workspace/'
       - '--accessAuthCode=${SIYUAN_ACCESS_AUTH_CODE}'
     user: '1000:1000'


### PR DESCRIPTION
Since the SiYuan kernel gained a CLI [1], serving over HTTP has been moved
behind an explicit `serve` subcommand. Starting the kernel with bare flags no
longer works, so the container currently exits without ever booting.

Verified against the pinned `b3log/siyuan:v3.7.3` image: the current command
prints the CLI help and exits, while prepending `serve` boots the kernel and
binds `0.0.0.0:6806` as expected.

[1]: https://github.com/siyuan-note/siyuan/issues/17866