### PR TITLE
Deprecate whoogle

### DIFF
--- a/apps/whoogle/config.json
+++ b/apps/whoogle/config.json
@@ -4,9 +4,10 @@
   "available": true,
   "exposable": true,
   "dynamic_config": true,
+  "deprecated": true,
   "port": 8255,
   "id": "whoogle",
-  "tipi_version": 18,
+  "tipi_version": 19,
   "version": "1.2.4",
   "categories": ["social"],
   "description": "Get Google search results, but without any ads, JavaScript, AMP links, cookies, or IP address tracking.",
@@ -16,6 +17,6 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1776233694546,
+  "updated_at": 1787329584655,
   "min_tipi_version": "4.5.0"
 }

--- a/apps/whoogle/metadata/description.md
+++ b/apps/whoogle/metadata/description.md
@@ -1,3 +1,12 @@
+# Deprecation Notice
+Whoogle is no longer functional, the app is now deprecated and will be soon removed from the appstore.
+
+See more details on the project page: https://github.com/benbusby/whoogle-search#whoogle-has-reached-the-end-of-the-road--24-jul-2026
+
+If you are looking for an alternative, you can try [SearXNG](./searxng)
+
+## Whoogle
+
 Get Google search results, but without any ads, JavaScript, AMP links, cookies, or IP address tracking. Easily deployable in one click as a Docker app, and customizable with a single config file. Quick and simple to implement as a primary search engine replacement on both desktop and mobile.
 
 ## Features


### PR DESCRIPTION
Whoogle project has been archived, it became non functional after some changes on Google side, a few months ago.