### PR TITLE
fix(wallos): add arm64 to supported architectures

### DIFF
--- a/apps/wallos/config.json
+++ b/apps/wallos/config.json
@@ -14,7 +14,7 @@
   "author": "Miguel Ribeiro",
   "source": "https://github.com/ellite/Wallos",
   "form_fields": [],
-  "supported_architectures": ["amd64"],
+  "supported_architectures": ["amd64", "arm64"],
   "created_at": 1691943801422,
   "updated_at": 1788596945406,
   "min_tipi_version": "4.5.0"


### PR DESCRIPTION
Wallos is currently hidden on arm64 devices (e.g. Raspberry Pi 4/5) because config.json only lists amd64.

The upstream image `bellamy/wallos` is published as a multi-arch image (amd64, arm64, arm/v7), including the pinned 5.5.0 tag, so no other changes are needed.

Change: "supported_architectures": ["amd64"] -> ["arm64", "amd64"]